### PR TITLE
Beta3.2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+name: Deploy
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/SiriDB/enodo-hub
+
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          file: docker/Dockerfile
+          tags: ghcr.io/SiriDB/enodo-hub:${{ steps.get_version.outputs.VERSION }},ghcr.io/SiriDB/enodo-hub:latest
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ test/*
 .idea
 .idea/*
 .idea/vcs.xml
-todo.txt
+restapi.md
 
 *.pyc
 *.pyo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Jobs get an unique identifier `config_name`, which can be set to now the `config_name` beforehand
 - Jobs can be silenced by the silenced property in the job config. This makes sure no events will be created for the job's results.
 - A job can require an other job the be run beforehand by using the `requires_job` property
+- Config section `enodo` renamed to `worker` because of env prefix `ENODO_`
 
 ### Fixed
 - PEP8 guidelines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  
 ## [Unreleased] - yyyy-mm-dd
 
+### Added
+- 
+
+### Changed
+- Changed series config and job config. Job config is now a list of jobs. Not categorised by job type. Forecast, anomaly detection jobs can be in the list multiple times. 
+- Jobs get an unique identifier `link_name`, which can be set to now the `link_name` beforehand
+- Jobs can be silenced by the silenced property in the job config. This makes sure no events will be created for the job's results.
+- A job can require an other job the be run beforehand by using the `requires_job` property
+
+### Fixed
+
+- 
+
 ## [0.1.0-beta3.0.0] - 2021-08-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - A job can require an other job the be run beforehand by using the `requires_job` property
 
 ### Fixed
-
-- 
+- PEP8 guidelines
 
 ## [0.1.0-beta3.0.0] - 2021-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,17 @@ All notable changes to this project will be documented in this file.
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
- 
+
 ## [Unreleased] - yyyy-mm-dd
 
+## [0.1.0-beta3.2.0] - yyyy-mm-dd
+
 ### Added
-- 
+- Seperate endpoints for fetching analysis result data
 
 ### Changed
 - Changed series config and job config. Job config is now a list of jobs. Not categorised by job type. Forecast, anomaly detection jobs can be in the list multiple times. 
-- Jobs get an unique identifier `link_name`, which can be set to now the `link_name` beforehand
+- Jobs get an unique identifier `config_name`, which can be set to now the `config_name` beforehand
 - Jobs can be silenced by the silenced property in the job config. This makes sure no events will be created for the job's results.
 - A job can require an other job the be run beforehand by using the `requires_job` property
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Jobs get an unique identifier `config_name`, which can be set to now the `config_name` beforehand
 - Jobs can be silenced by the silenced property in the job config. This makes sure no events will be created for the job's results.
 - A job can require an other job the be run beforehand by using the `requires_job` property
-- Config section `enodo` renamed to `worker` because of env prefix `ENODO_`
+- Config section `enodo` renamed to `hub` because of env prefix `ENODO_`
 
 ### Fixed
 - PEP8 guidelines

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM python:3.8
+COPY . /opt/siridb-enodo-hub
+WORKDIR /opt/siridb-enodo-hub
+RUN pip install -r requirements.txt
+
+# Client (Socket) connections
+EXPOSE 9103
+# Web api and websockets
+EXPOSE 80
+
+# Overwrite default configuration parameters
+ENV INTERNAL_SOCKET_SERVER_PORT 9103
+ENV INTERNAL_SOCKET_SERVER_HOSTNAME 0.0.0.0
+ENV BASIC_AUTH_USERNAME enodo
+ENV BASIC_AUTH_PASSWORD enodo
+ENV LOG_PATH /tmp/enodo/log.log
+ENV CLIENT_MAX_TIMEOUT 35
+ENV SERIES_SAVE_PATH /tmp/enodo/series
+ENV ENODO_BASE_SAVE_PATH /tmp/enodo
+ENV SAVE_TO_DISK_INTERVAL 20
+ENV ENABLE_REST_API true
+ENV ENABLE_SOCKET_IO_API true
+ENV DISABLE_SAFE_MODE true
+ENV MAX_IN_QUEUE_BEFORE_WARNING 25
+ENV MIN_DATA_POINTS 10
+ENV WATCHER_INTERVAL 1
+ENV SIRIDB_CONNECTION_CHECK_INTERVAL 30
+ENV INTERVAL_SCHEDULES_SERIES 3600
+
+CMD ["/opt/siridb-enodo-hub/main.py"]
+
+ENTRYPOINT ["python"]

--- a/apidocgenerator.py
+++ b/apidocgenerator.py
@@ -1,0 +1,58 @@
+import re
+from aiohttp import web
+import aiohttp_cors
+
+from lib.webserver.routes import setup_routes
+
+
+def generate_api_docs(app):
+    mdstring = ""
+    mdstring += "|endpoint|method|description|args|\n"
+    mdstring += "|--------|------|-----------|----|\n"
+    for route in list(app.router.routes()):
+        if hasattr(route.handler.__self__, "__name__") and \
+                route.handler.__self__.__name__ == "ApiHandlers":
+            docs = route.handler.__doc__
+            uri = ""
+            method = route.method
+            if hasattr(route.resource, "_path"):
+                uri = route.resource._path
+            elif hasattr(route.resource, "_formatter"):
+                uri = route.resource._formatter
+
+            if method != "HEAD":
+                desc = re.search(
+                    r"\A(.*?)\n\n", docs, re.MULTILINE | re.DOTALL)
+                matches = re.search(
+                    r"(?:(?:\s{,8}Query args)|(?:\s{,8}JSON POST data)):\n(.*?)(?=(?:\n{2,})|(?:\s{,8}\n))",
+                    docs, re.MULTILINE | re.DOTALL)
+                if desc:
+                    desc = desc.group(0)
+                if matches:
+                    matches = [
+                        matches.group(groupNum)
+                        for groupNum in range(0, len(matches.groups()))]
+                argdocs = ""
+                if matches:
+                    for m in matches:
+                        argdocs += m
+
+                desc = desc.replace("\n", "")
+                argdocs = argdocs.replace("\n", "")
+                mdstring += f"|{uri}|{method}|{desc}|{argdocs}|\n"
+    with open('restapi.md', 'w') as f:
+        f.write(mdstring)
+    f.close()
+
+
+if __name__ == '__main__':
+    app = web.Application()
+    cors = aiohttp_cors.setup(app, defaults={
+        "*": aiohttp_cors.ResourceOptions(
+            allow_credentials=True,
+            expose_headers="*",
+            allow_headers="*",
+        )
+    })
+    setup_routes(app, cors)
+    generate_api_docs(app)

--- a/lib/analyser/analyserwrapper.py
+++ b/lib/analyser/analyserwrapper.py
@@ -5,7 +5,15 @@ GENERAL_PARAMETERS = {
 
 
 async def setup_default_model_arguments(model_arguments):
-    for key in GENERAL_PARAMETERS.keys():
+    """Setup default model params
+
+    Args:
+        model_arguments (dict): model params
+
+    Returns:
+        dict: params
+    """
+    for key in GENERAL_PARAMETERS:
         if key not in model_arguments:
             model_arguments[key] = GENERAL_PARAMETERS[key]
 

--- a/lib/analyser/model.py
+++ b/lib/analyser/model.py
@@ -5,7 +5,8 @@ import os
 from enodo import EnodoModel
 from lib.config import Config
 from lib.util import load_disk_data, save_disk_data
-from lib.socketio import SUBSCRIPTION_CHANGE_TYPE_ADD, SUBSCRIPTION_CHANGE_TYPE_DELETE
+from lib.socketio import SUBSCRIPTION_CHANGE_TYPE_ADD, \
+    SUBSCRIPTION_CHANGE_TYPE_DELETE
 
 
 class EnodoModelManager:
@@ -28,13 +29,15 @@ class EnodoModelManager:
         if await cls.get_model(name) is None:
             model = EnodoModel(name, model_arguments)
             cls.models.append(model)
-            await cls._update_cb(SUBSCRIPTION_CHANGE_TYPE_ADD, EnodoModel.to_dict(model))
+            await cls._update_cb(
+                SUBSCRIPTION_CHANGE_TYPE_ADD, EnodoModel.to_dict(model))
 
     @classmethod
     async def add_enodo_model(cls, model):
         if await cls.get_model(model.name) is None:
             cls.models.append(model)
-            await cls._update_cb(SUBSCRIPTION_CHANGE_TYPE_ADD, EnodoModel.to_dict(model))
+            await cls._update_cb(
+                SUBSCRIPTION_CHANGE_TYPE_ADD, EnodoModel.to_dict(model))
             return True
         return False
 
@@ -69,5 +72,6 @@ class EnodoModelManager:
         try:
             save_disk_data(Config.model_save_path, model_list)
         except Exception as e:
-            logging.error(f"Something went wrong when writing enodo models to disk")
+            logging.error(f"Something went wrong when writing \
+                enodo models to disk")
             logging.debug(f"Corresponding error: {e}")

--- a/lib/analyser/model.py
+++ b/lib/analyser/model.py
@@ -73,4 +73,5 @@ class EnodoModelManager:
         except Exception as e:
             logging.error(f"Something went wrong when writing"
                           f"enodo models to disk")
-            logging.debug(f"Corresponding error: {e}")
+            logging.debug(f"Corresponding error: {e}, "
+                          f'exception class: {e.__class__.__name__}')

--- a/lib/analyser/model.py
+++ b/lib/analyser/model.py
@@ -1,8 +1,7 @@
-import json
-from lib.util.util import load_disk_data
 import os
 
 from enodo import EnodoModel
+
 from lib.config import Config
 from lib.util import load_disk_data, save_disk_data
 from lib.socketio import SUBSCRIPTION_CHANGE_TYPE_ADD, \

--- a/lib/analyser/model.py
+++ b/lib/analyser/model.py
@@ -71,6 +71,6 @@ class EnodoModelManager:
         try:
             save_disk_data(Config.model_save_path, model_list)
         except Exception as e:
-            logging.error(f"Something went wrong when writing \
-                enodo models to disk")
+            logging.error(f"Something went wrong when writing"
+                          f"enodo models to disk")
             logging.debug(f"Corresponding error: {e}")

--- a/lib/api/apihandlers.py
+++ b/lib/api/apihandlers.py
@@ -24,10 +24,16 @@ class ApiHandlers:
     @classmethod
     @EnodoAuth.auth.required
     async def get_monitored_series(cls, request):
-        """
-        Returns a list of monitored series
-        :param request:
-        :return:
+        """Returns a list of monitored series
+
+        Args:
+            request (Request): aiohttp request
+
+        Returns:
+            _type_: _description_
+
+        Query args:
+            filter (String): regex filter
         """
         regex_filter = urllib.parse.unquote(
             request.rel_url.query['filter']) \
@@ -40,29 +46,82 @@ class ApiHandlers:
 
     @classmethod
     @EnodoAuth.auth.required
-    async def get_monitored_series_details(cls, request):
+    async def get_single_monitored_series(cls, request):
+        """Returns all details and data points of a specific series.
+
+        Args:
+            request (Request): aiohttp request
+
+        Returns:
+            _type_: _description_
         """
-        Returns all details and data points of a specific series.
-        :param request:
-        :return:
-        """
-        include_points = True \
-            if 'include_points' in request.rel_url.query and \
-            request.rel_url.query['include_points'] == 'true' else False
         series_name = unquote(request.match_info['series_name'])
 
         return web.json_response(
-            data=await BaseHandler.resp_get_monitored_series_details(
-                series_name, include_points),
-            dumps=safe_json_dumps)
+            data=await BaseHandler.resp_get_single_monitored_series(
+                series_name), dumps=safe_json_dumps)
+
+    @classmethod
+    @EnodoAuth.auth.required
+    async def get_series_forecast(cls, request):
+        """Returns forecast data of a specific series.
+
+        Args:
+            request (Request): aiohttp request
+
+        Returns:
+            _type_: _description_
+        """
+        series_name = unquote(request.match_info['series_name'])
+
+        return web.json_response(
+            data=await BaseHandler.resp_get_series_forecasts(
+                series_name), dumps=safe_json_dumps)
+
+    @classmethod
+    @EnodoAuth.auth.required
+    async def get_series_anomalies(cls, request):
+        """Returns anomalies data of a specific series.
+
+        Args:
+            request (Request): aiohttp request
+
+        Returns:
+            _type_: _description_
+        """
+        series_name = unquote(request.match_info['series_name'])
+
+        return web.json_response(
+            data=await BaseHandler.resp_get_series_anomalies(
+                series_name), dumps=safe_json_dumps)
+
+    @classmethod
+    @EnodoAuth.auth.required
+    async def get_series_static_rules_hits(cls, request):
+        """Returns static rules hits of a specific series.
+
+        Args:
+            request (Request): aiohttp request
+
+        Returns:
+            _type_: _description_
+        """
+        series_name = unquote(request.match_info['series_name'])
+
+        return web.json_response(
+            data=await BaseHandler.resp_get_series_static_rules_hits(
+                series_name), dumps=safe_json_dumps)
 
     @classmethod
     @EnodoAuth.auth.required
     async def add_series(cls, request):
-        """
-        Add new series to the application.
-        :param request:
-        :return:
+        """Add new series to monitor.
+
+        Args:
+            request (Request): aiohttp request
+
+        Returns:
+            _type_: _description_
         """
         data = await request.json()
         resp, status = await BaseHandler.resp_add_series(data)
@@ -71,10 +130,13 @@ class ApiHandlers:
     @classmethod
     @EnodoAuth.auth.required
     async def remove_series(cls, request):
-        """
-        Remove series with certain name
-        :param request:
-        :return:
+        """Remove series with specific name
+
+        Args:
+            request (Request): aiohttp request
+
+        Returns:
+            _type_: _description_
         """
         series_name = urllib.parse.unquote(
             request.match_info['series_name'])
@@ -84,10 +146,13 @@ class ApiHandlers:
     @classmethod
     @EnodoAuth.auth.required
     async def get_enodo_event_outputs(cls, request):
-        """
-        Get all event outputs.
-        :param request:
-        :return:
+        """Get all event outputs
+
+        Args:
+            request (Request): aiohttp request
+
+        Returns:
+            _type_: _description_
         """
         resp, status = await BaseHandler.resp_get_event_outputs()
         return web.json_response(data=resp, status=status)
@@ -95,10 +160,17 @@ class ApiHandlers:
     @classmethod
     @EnodoAuth.auth.required
     async def add_enodo_event_output(cls, request):
-        """
-        Add a new event output.
-        :param request:
-        :return:
+        """Add a new event output
+
+        Args:
+            request (Request): aiohttp request
+
+        Returns:
+            _type_: _description_
+
+        JSON POST data:
+            output_type (int): type of output stream
+            data        (Object): data for output
         """
         data = await request.json()
         output_type = data.get('output_type')
@@ -111,10 +183,13 @@ class ApiHandlers:
     @classmethod
     @EnodoAuth.auth.required
     async def remove_enodo_event_output(cls, request):
-        """
-        Add a new event output.
-        :param request:
-        :return:
+        """Add a new event output
+
+        Args:
+            request (Request): aiohttp request
+
+        Returns:
+            _type_: _description_
         """
         output_id = int(request.match_info['output_id'])
 
@@ -124,10 +199,13 @@ class ApiHandlers:
     @classmethod
     @EnodoAuth.auth.required
     async def get_possible_analyser_models(cls, request):
-        """
-        Returns list of possible models with corresponding parameters
-        :param request:
-        :return:
+        """Returns list of possible models with corresponding parameters
+
+        Args:
+            request (Request): aiohttp request
+
+        Returns:
+            _type_: _description_
         """
 
         return web.json_response(
@@ -137,10 +215,13 @@ class ApiHandlers:
     @classmethod
     @EnodoAuth.auth.required
     async def add_analyser_models(cls, request):
-        """
-        Returns list of possible models with corresponding parameters
-        :param request:
-        :return:
+        """Returns list of possible models with corresponding parameters
+
+        Args:
+            request (Request): aiohttp request
+
+        Returns:
+            _type_: _description_
         """
         data = await request.json()
         resp, status = await BaseHandler.resp_add_model(data)
@@ -149,20 +230,26 @@ class ApiHandlers:
     @classmethod
     @EnodoAuth.auth.required
     async def get_siridb_enodo_status(cls, request):
-        """
-        Get status of this analyser instance
-        :param request:
-        :return:
+        """Get status of enodo hub
+
+        Args:
+            request (Request): aiohttp request
+
+        Returns:
+            _type_: _description_
         """
         resp = await BaseHandler.resp_get_enodo_hub_status()
         return web.json_response(data=resp, status=200)
 
     @classmethod
     async def get_enodo_readiness(cls, request):
-        """
-        Get status of this analyser instance
-        :param request:
-        :return:
+        """Get status of this analyser instance
+
+        Args:
+            request (Request): aiohttp request
+
+        Returns:
+            _type_: _description_
         """
         ready = ServerState.get_readiness()
         return web.Response(
@@ -172,10 +259,13 @@ class ApiHandlers:
     @classmethod
     @EnodoAuth.auth.required
     async def get_event_log(cls, request):
-        """
-        Returns event log
-        :param request:
-        :return:
+        """Returns enodo event log
+
+        Args:
+            request (Request): aiohttp request
+
+        Returns:
+            _type_: _description_
         """
         log = ""
         return web.json_response(data={'data': log}, status=200)
@@ -183,12 +273,31 @@ class ApiHandlers:
     @classmethod
     @EnodoAuth.auth.required
     async def get_settings(cls, request):
+        """Returns current settings dict
+
+        Args:
+            request (Request): aiohttp request
+
+        Returns:
+            _type_: _description_
+        """
         resp = await BaseHandler.resp_get_enodo_config()
         return web.json_response(data=resp, status=200)
 
     @classmethod
     @EnodoAuth.auth.required
     async def update_settings(cls, request):
+        """Update settings
+
+        Args:
+            request (Request): aiohttp request
+
+        Returns:
+            _type_: _description_
+
+        JSON POST data:
+            key/value pairs settings
+        """
         data = await request.json()
         resp = await BaseHandler.resp_set_config(data)
         return web.json_response(data=resp, status=200)
@@ -196,10 +305,13 @@ class ApiHandlers:
     @classmethod
     @EnodoAuth.auth.required
     async def get_connected_clients(cls, request):
-        """
-        Return connected listeners and workers
-        :param request:
-        :return:
+        """Return connected listeners and workers
+
+        Args:
+            request (Request): aiohttp request
+
+        Returns:
+            _type_: _description_
         """
         return web.json_response(data={
             'data': {
@@ -215,10 +327,13 @@ class ApiHandlers:
     @classmethod
     @EnodoAuth.auth.required
     async def get_enodo_stats(cls, request):
-        """
-        Return stats and numbers from enodo domain
-        :param request:
-        :return:
+        """Return stats and numbers from enodo domain
+
+        Args:
+            request (Request): aiohttp request
+
+        Returns:
+            _type_: _description_
         """
         resp = await BaseHandler.resp_get_enodo_stats()
         return web.json_response(data={
@@ -227,10 +342,13 @@ class ApiHandlers:
     @classmethod
     @EnodoAuth.auth.required
     async def get_enodo_labels(cls, request):
-        """
-        Return enodo labels and last update timestamp
-        :param request:
-        :return:
+        """Return enodo labels and last update timestamp
+
+        Args:
+            request (Request): aiohttp request
+
+        Returns:
+            _type_: _description_
         """
         resp = await BaseHandler.resp_get_enodo_labels()
         return web.json_response(data={
@@ -239,10 +357,18 @@ class ApiHandlers:
     @classmethod
     @EnodoAuth.auth.required
     async def add_enodo_label(cls, request):
-        """
-        Add enodo label
-        :param request:
-        :return:
+        """Add enodo label
+
+        Args:
+            request (Request): aiohttp request
+
+        Returns:
+            _type_: _description_
+
+        JSON POST data:
+            description (String): description of the label
+            name (String): name of the label
+            series_config (Object): series config to assign to child series of label
         """
         data = await request.json()
         resp = await BaseHandler.resp_add_enodo_label(data)
@@ -252,10 +378,13 @@ class ApiHandlers:
     @classmethod
     @EnodoAuth.auth.required
     async def remove_enodo_label(cls, request):
-        """
-        Remove enodo label
-        :param request:
-        :return:
+        """Remove enodo label
+
+        Args:
+            request (Request): aiohttp request
+
+        Returns:
+            _type_: _description_
         """
         data = await request.json()
         resp = await BaseHandler.resp_remove_enodo_label(data)

--- a/lib/api/apihandlers.py
+++ b/lib/api/apihandlers.py
@@ -214,21 +214,6 @@ class ApiHandlers:
 
     @classmethod
     @EnodoAuth.auth.required
-    async def add_analyser_models(cls, request):
-        """Returns list of possible models with corresponding parameters
-
-        Args:
-            request (Request): aiohttp request
-
-        Returns:
-            _type_: _description_
-        """
-        data = await request.json()
-        resp, status = await BaseHandler.resp_add_model(data)
-        return web.json_response(data=resp, status=status)
-
-    @classmethod
-    @EnodoAuth.auth.required
     async def get_siridb_enodo_status(cls, request):
         """Get status of enodo hub
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -8,7 +8,7 @@ from lib.exceptions.enodoexception import EnodoInvalidConfigException, \
     EnodoException
 
 EMPTY_CONFIG_FILE = {
-    'enodo': {
+    'hub': {
         'basic_auth_username': 'enodo',
         'basic_auth_password': 'enodo',
         'log_path': '',
@@ -64,7 +64,7 @@ class EnodoConfigParser(RawConfigParser):
             pass
 
         if self.env_support:
-            env_value = os.getenv(option.upper())
+            env_value = os.getenv(f"ENODO_{section.upper()}_{option.upper()}")
             if env_value is not None:
                 value = env_value
 
@@ -236,34 +236,34 @@ class Config:
 
         # Enodo
         cls.basic_auth_username = cls._config.get_r(
-            'enodo', 'basic_auth_username', required=False, default=None)
+           'hub', 'basic_auth_username', required=False, default=None)
         cls.basic_auth_password = cls._config.get_r(
-            'enodo', 'basic_auth_password', required=False, default=None)
+           'hub', 'basic_auth_password', required=False, default=None)
 
         cls.client_max_timeout = cls.to_int(
-            cls._config.get_r('enodo', 'client_max_timeout'))
+            cls._config.get_r('hub', 'client_max_timeout'))
         if cls.client_max_timeout < 35:  # min value enforcement
             cls.client_max_timeout = 35
         cls.socket_server_host = cls._config.get_r(
-            'enodo', 'internal_socket_server_hostname')
+           'hub', 'internal_socket_server_hostname')
         cls.socket_server_port = cls.to_int(
-            cls._config.get_r('enodo', 'internal_socket_server_port'))
+            cls._config.get_r('hub', 'internal_socket_server_port'))
         cls.save_to_disk_interval = cls.to_int(
-            cls._config.get_r('enodo', 'save_to_disk_interval'))
+            cls._config.get_r('hub', 'save_to_disk_interval'))
         cls.enable_rest_api = cls.to_bool(
             cls._config.get_r(
-                'enodo', 'enable_rest_api', required=False,
+               'hub', 'enable_rest_api', required=False,
                 default='true'),
             True)
         cls.enable_socket_io_api = cls.to_bool(
             cls._config.get_r(
-                'enodo', 'enable_socket_io_api', required=False,
+               'hub', 'enable_socket_io_api', required=False,
                 default='false'),
             False)
         cls.base_dir = cls._config.get_r(
-            'enodo', 'enodo_base_save_path')
+           'hub', 'enodo_base_save_path')
         cls.disable_safe_mode = cls.to_bool(
-            cls._config.get_r('enodo', 'disable_safe_mode'), False)
+            cls._config.get_r('hub', 'disable_safe_mode'), False)
         cls.log_path = os.path.join(cls.base_dir, 'log.log')
         cls.series_save_path = os.path.join(
             cls.base_dir, 'data/series.json')

--- a/lib/enodojobmanager.py
+++ b/lib/enodojobmanager.py
@@ -124,10 +124,10 @@ class EnodoJobManager:
         return [job for job in cls._active_jobs if job.worker_id == worker_id]
 
     @classmethod
-    async def create_job(cls, job_link_name, series_name):
+    async def create_job(cls, job_config_name, series_name):
         series = await SeriesManager.get_series(series_name)
-        await series.set_job_status(job_link_name, JOB_STATUS_OPEN)
-        job_config = series.get_job(job_link_name)
+        await series.set_job_status(job_config_name, JOB_STATUS_OPEN)
+        job_config = series.get_job(job_config_name)
         job_id = await cls._get_next_job_id()
         job = EnodoJob(job_id, series_name, job_config,
                        job_data=None)  # TODO: Catch exception
@@ -324,7 +324,7 @@ class EnodoJobManager:
 
                     worker = await ClientManager.get_free_worker(
                         next_job.series_name, next_job.job_config.job_type,
-                        await series.get_model(next_job.job_config.link_name))
+                        await series.get_model(next_job.job_config.config_name))
                     if worker is None:
                         continue
 
@@ -362,11 +362,11 @@ class EnodoJobManager:
             try:
                 await SeriesManager.add_forecast_to_series(
                     data.get('name'),
-                    job.job_config.link_name,
+                    job.job_config.config_name,
                     data.get('points'))
                 await series.set_job_status(
-                    job.job_config.link_name, JOB_STATUS_DONE)
-                await series.schedule_job(job.job_config.link_name)
+                    job.job_config.config_name, JOB_STATUS_DONE)
+                await series.schedule_job(job.job_config.config_name)
                 await SeriesManager.series_changed(
                     SUBSCRIPTION_CHANGE_TYPE_UPDATE, data.get('name'))
             except Exception as e:
@@ -381,11 +381,11 @@ class EnodoJobManager:
                 try:
                     await SeriesManager.add_anomalies_to_series(
                         data.get('name'),
-                        job.job_config.link_name,
+                        job.job_config.config_name,
                         data.get('anomalies'))
                     await series.set_job_status(
-                        job.job_config.link_name, JOB_STATUS_DONE)
-                    await series.schedule_job(job.job_config.link_name)
+                        job.job_config.config_name, JOB_STATUS_DONE)
+                    await series.schedule_job(job.job_config.config_name)
                     await SeriesManager.series_changed(
                         SUBSCRIPTION_CHANGE_TYPE_UPDATE, data.get('name'))
                 except Exception as e:
@@ -399,8 +399,8 @@ class EnodoJobManager:
                     'data').get('characteristics')
                 series.state.health = data.get('data').get('health')
                 await series.set_job_status(
-                    job.job_config.link_name, JOB_STATUS_DONE)
-                await series.schedule_job(job.job_config.link_name)
+                    job.job_config.config_name, JOB_STATUS_DONE)
+                await series.schedule_job(job.job_config.config_name)
                 await SeriesManager.series_changed(
                     SUBSCRIPTION_CHANGE_TYPE_UPDATE, data.get('name'))
             except Exception as e:
@@ -410,8 +410,8 @@ class EnodoJobManager:
         elif job_type == JOB_TYPE_STATIC_RULES:
             try:
                 await series.set_job_status(
-                    job.job_config.link_name, JOB_STATUS_DONE)
-                await series.schedule_job(job.job_config.link_name)
+                    job.job_config.config_name, JOB_STATUS_DONE)
+                await series.schedule_job(job.job_config.config_name)
                 if len(data.get('failed_checks')):
                     for key in data.get('failed_checks'):
                         event = EnodoEvent(

--- a/lib/enodojobmanager.py
+++ b/lib/enodojobmanager.py
@@ -337,7 +337,9 @@ class EnodoJobManager:
                 except Exception as e:
                     logging.error(
                         "Something went wrong when trying to activate job")
-                    logging.debug(f"Corresponding error: {e}")
+                    logging.debug(
+                        f"Corresponding error: {e}, "
+                        f'exception class: {e.__class__.__name__}')
                 finally:
                     cls._unlock()
             await cls.clean_jobs()
@@ -372,7 +374,9 @@ class EnodoJobManager:
             except Exception as e:
                 logging.error(
                     f"Something went wrong when receiving forecast job")
-                logging.debug(f"Corresponding error: {e}")
+                logging.debug(
+                    f"Corresponding error: {e}, "
+                    f'exception class: {e.__class__.__name__}')
         elif job_type == JOB_TYPE_DETECT_ANOMALIES_FOR_SERIES:
             if isinstance(
                     data.get('anomalies'),
@@ -392,7 +396,9 @@ class EnodoJobManager:
                     logging.error(
                         f"Something went wrong when receiving"
                         f"anomaly detection job")
-                    logging.debug(f"Corresponding error: {e}")
+                    logging.debug(
+                        f"Corresponding error: {e}, "
+                        f'exception class: {e.__class__.__name__}')
         elif job_type == JOB_TYPE_BASE_SERIES_ANALYSIS:
             try:
                 series.series_characteristics = data.get(
@@ -406,7 +412,9 @@ class EnodoJobManager:
             except Exception as e:
                 logging.error(
                     f"Something went wrong when receiving base analysis job")
-                logging.debug(f"Corresponding error: {e}")
+                logging.debug(
+                    f"Corresponding error: {e}, "
+                    f'exception class: {e.__class__.__name__}')
         elif job_type == JOB_TYPE_STATIC_RULES:
             try:
                 await series.set_job_status(
@@ -428,7 +436,9 @@ class EnodoJobManager:
             except Exception as e:
                 logging.error(
                     f"Something went wrong when receiving static rules job")
-                logging.debug(f"Corresponding error: {e}")
+                logging.debug(
+                    f"Corresponding error: {e}, "
+                    f'exception class: {e.__class__.__name__}')
         else:
             logging.error(f"Received unknown job type: {job_type}")
 
@@ -448,7 +458,8 @@ class EnodoJobManager:
                 f"Something went wrong when sending job request to worker")
             import traceback
             traceback.print_exc()
-            logging.debug(f"Corresponding error: {e}")
+            logging.debug(f"Corresponding error: {e}, "
+                          f'exception class: {e.__class__.__name__}')
 
     @classmethod
     async def _send_worker_cancel_job(cls, worker_id, job_id):
@@ -465,7 +476,8 @@ class EnodoJobManager:
         except Exception as e:
             logging.error(
                 f"Something went wrong when sending worker to cancel job")
-            logging.debug(f"Corresponding error: {e}")
+            logging.debug(f"Corresponding error: {e}, "
+                          f'exception class: {e.__class__.__name__}')
 
     @classmethod
     async def receive_worker_cancelled_job(cls, writer, packet_type,
@@ -485,7 +497,8 @@ class EnodoJobManager:
             logging.error(
                 f"Something went wrong when"
                 f"receiving from worker to cancel job")
-            logging.debug(f"Corresponding error: {e}")
+            logging.debug(f"Corresponding error: {e}, "
+                          f'exception class: {e.__class__.__name__}')
 
     @classmethod
     async def get_open_queue(cls):
@@ -504,7 +517,8 @@ class EnodoJobManager:
         except Exception as e:
             logging.error(
                 f"Something went wrong when saving jobmanager data to disk")
-            logging.debug(f"Corresponding error: {e}")
+            logging.debug(f"Corresponding error: {e}, "
+                          f'exception class: {e.__class__.__name__}')
         cls._unlock()
 
     @classmethod

--- a/lib/enodojobmanager.py
+++ b/lib/enodojobmanager.py
@@ -1,33 +1,35 @@
 import asyncio
 import datetime
-import json
 import logging
 import os
 import datetime
 
 import qpack
 from enodo.jobs import *
-from enodo.protocol.packagedata import EnodoJobDataModel, EnodoJobRequestDataModel
-from enodo.model.config.worker import WORKER_MODE_GLOBAL, WORKER_MODE_DEDICATED_JOB_TYPE, \
-    WORKER_MODE_DEDICATED_SERIES
+from enodo.protocol.packagedata import EnodoJobDataModel, \
+    EnodoJobRequestDataModel
 
-from .events.enodoeventmanager import EnodoEvent, EnodoEventManager, ENODO_EVENT_JOB_QUEUE_TOO_LONG, ENODO_EVENT_STATIC_RULE_FAIL
+from .events.enodoeventmanager import EnodoEvent, EnodoEventManager, \
+    ENODO_EVENT_JOB_QUEUE_TOO_LONG, ENODO_EVENT_STATIC_RULE_FAIL
 from .config import Config
 from .series.seriesmanager import SeriesManager
-from .series import SERIES_ANALYSED_STATUS_DONE
 from .serverstate import ServerState
 from .socket import ClientManager
 from .socket.package import create_header, WORKER_JOB, WORKER_JOB_CANCEL
 from .socketio import SUBSCRIPTION_CHANGE_TYPE_UPDATE
 from lib.util import load_disk_data, save_disk_data
-from .socketio import SUBSCRIPTION_CHANGE_TYPE_DELETE, SUBSCRIPTION_CHANGE_TYPE_ADD
+from .socketio import SUBSCRIPTION_CHANGE_TYPE_DELETE, \
+    SUBSCRIPTION_CHANGE_TYPE_ADD
 
 
 class EnodoJob:
-    __slots__ = ('rid', 'series_name', 'job_config', 'job_data', 'send_at', 'error', 'worker_id')
+    __slots__ = ('rid', 'series_name', 'job_config',
+                 'job_data', 'send_at', 'error', 'worker_id')
 
-    def __init__(self, rid, series_name, job_config, job_data=None, send_at=None, error=None, worker_id=None):
-        if not isinstance(job_data, EnodoJobDataModel) and job_data is not None:
+    def __init__(self, rid, series_name, job_config, job_data=None,
+                 send_at=None, error=None, worker_id=None):
+        if not isinstance(
+                job_data, EnodoJobDataModel) and job_data is not None:
             raise Exception('Unknown job data value')
         self.rid = rid
         self.series_name = series_name
@@ -53,10 +55,10 @@ class EnodoJob:
 
 
 class EnodoJobManager:
-    _open_jobs = None
-    _active_jobs = None
-    _active_jobs_index = None
-    _failed_jobs = None
+    _open_jobs = []
+    _active_jobs = []
+    _active_jobs_index = {}
+    _failed_jobs = []
     _max_job_id = 1000
     _max_job_timeout = 60 * 5
     _next_job_id = None
@@ -68,11 +70,7 @@ class EnodoJobManager:
     @classmethod
     async def async_setup(cls, update_queue_cb):
         cls._next_job_id = 0
-        cls._open_jobs = []
-        cls._active_jobs = []
-        cls._active_jobs_index = {}
-        cls._failed_jobs = []
-        
+
         cls._update_queue_cb = update_queue_cb
         cls._max_in_queue_before_warning = Config.max_in_queue_before_warning
 
@@ -125,13 +123,13 @@ class EnodoJobManager:
     def get_active_jobs_by_worker(cls, worker_id):
         return [job for job in cls._active_jobs if job.worker_id == worker_id]
 
-
     @classmethod
     async def create_job(cls, job_link_name, series_name):
         series = await SeriesManager.get_series(series_name)
         job_config = series.get_job(job_link_name)
         job_id = await cls._get_next_job_id()
-        job = EnodoJob(job_id, series_name, job_config, job_data=None)  # TODO: Catch exception
+        job = EnodoJob(job_id, series_name, job_config,
+                       job_data=None)  # TODO: Catch exception
         await series.set_job_status(job_link_name, JOB_STATUS_OPEN)
         await cls._add_job(job)
 
@@ -142,7 +140,8 @@ class EnodoJobManager:
 
         cls._open_jobs.append(job)
         if cls._update_queue_cb is not None:
-            await cls._update_queue_cb(SUBSCRIPTION_CHANGE_TYPE_ADD, EnodoJob.to_dict(job))
+            await cls._update_queue_cb(
+                SUBSCRIPTION_CHANGE_TYPE_ADD, EnodoJob.to_dict(job))
 
     @classmethod
     def has_series_failed_jobs(cls, series_name):
@@ -188,7 +187,8 @@ class EnodoJobManager:
         if job in cls._open_jobs:
             cls._open_jobs.remove(job)
             if cls._update_queue_cb is not None:
-                await cls._update_queue_cb(SUBSCRIPTION_CHANGE_TYPE_DELETE, job.rid)
+                await cls._update_queue_cb(
+                    SUBSCRIPTION_CHANGE_TYPE_DELETE, job.rid)
         job.send_at = datetime.datetime.now()
         job.worker_id = worker_id
         cls._active_jobs.append(job)
@@ -247,10 +247,11 @@ class EnodoJobManager:
         for job in jobs:
             cls._open_jobs.remove(job)
             if cls._update_queue_cb is not None:
-                await cls._update_queue_cb(SUBSCRIPTION_CHANGE_TYPE_DELETE, job.rid)
+                await cls._update_queue_cb(
+                    SUBSCRIPTION_CHANGE_TYPE_DELETE, job.rid)
 
         jobs = []
-        
+
         for job in cls._active_jobs:
             if job.series_name == series_name:
                 jobs.append(job)
@@ -258,8 +259,8 @@ class EnodoJobManager:
         for job in jobs:
             cls._active_jobs.remove(job)
             if cls._update_queue_cb is not None:
-                await cls._update_queue_cb(SUBSCRIPTION_CHANGE_TYPE_DELETE, job.rid)
-            
+                await cls._update_queue_cb(
+                    SUBSCRIPTION_CHANGE_TYPE_DELETE, job.rid)
 
     @classmethod
     async def set_job_failed(cls, job_id, error):
@@ -288,112 +289,159 @@ class EnodoJobManager:
         await cls._lock()
 
         for job in cls._active_jobs:
-            if (datetime.datetime.now() - job.send_at).total_seconds() > cls._max_job_timeout:
+            now = datetime.datetime.now()
+            if (now - job.send_at).total_seconds() > cls._max_job_timeout:
                 await cls._set_job_failed(job, "Job timed-out")
                 await cls._send_worker_cancel_job(job.worker_id, job.rid)
         cls._unlock()
 
         if len(cls._open_jobs) > cls._max_in_queue_before_warning:
-            event = EnodoEvent('Job queue too long', f'{len(cls._open_jobs)} jobs waiting \
-                in queue exceeds threshold of {cls._max_in_queue_before_warning}', 
+            event = EnodoEvent(
+                'Job queue too long',
+                f'{len(cls._open_jobs)} jobs waiting \
+                in queue exceeds threshold of \
+                    {cls._max_in_queue_before_warning}',
                 ENODO_EVENT_JOB_QUEUE_TOO_LONG)
             await EnodoEventManager.handle_event(event)
 
     @classmethod
     async def check_for_jobs(cls):
         while ServerState.running:
-            ServerState.tasks_last_runs['check_jobs'] = datetime.datetime.now()
-            if len(cls._open_jobs) > 0:
-                for next_job in cls._open_jobs:
-                    try:
-                        await cls._lock()
-                        series = await SeriesManager.get_series(next_job.series_name)
-                        if series is not None:
-                            worker = await ClientManager.get_free_worker(next_job.series_name, next_job.job_config.job_type, await series.get_model(next_job.job_config.link_name))
-                            if worker is not None:
-                                logging.info(f"Adding series: sending {next_job.series_name} to Worker for job type {next_job.job_config.job_type}")
-                                await cls._send_worker_job_request(worker, next_job)
-                                worker.is_going_busy = True
-                                await cls._activate_job(next_job, worker.client_id)
-                    except Exception as e:
-                        logging.error(f"Something went wrong when trying to activate job")
-                        logging.debug(f"Corresponding error: {e}")
-                    finally:
-                        cls._unlock()
+            ServerState.tasks_last_runs['check_jobs'] = datetime.datetime.now(
+            )
+            if len(cls._open_jobs) == 0:
+                await cls.clean_jobs()
+                await asyncio.sleep(Config.watcher_interval)
+                continue
+
+            for next_job in cls._open_jobs:
+                try:
+                    await cls._lock()
+                    series = await SeriesManager.get_series(
+                        next_job.series_name)
+                    if series is None:
+                        continue
+
+                    worker = await ClientManager.get_free_worker(
+                        next_job.series_name, next_job.job_config.job_type,
+                        await series.get_model(next_job.job_config.link_name))
+                    if worker is None:
+                        continue
+
+                    logging.info(
+                        f"Adding series: sending {next_job.series_name} to \
+                            Worker for job type {next_job.job_config.job_type}")
+                    await cls._send_worker_job_request(worker, next_job)
+                    worker.is_going_busy = True
+                    await cls._activate_job(next_job, worker.client_id)
+                except Exception as e:
+                    logging.error(
+                        f"Something went wrong when trying to activate job")
+                    logging.debug(f"Corresponding error: {e}")
+                finally:
+                    cls._unlock()
             await cls.clean_jobs()
             await asyncio.sleep(Config.watcher_interval)
 
     @classmethod
-    async def receive_job_result(cls, writer, packet_type, packet_id, data, client_id):
+    async def receive_job_result(cls, writer, packet_type,
+                                 packet_id, data, client_id):
         job_id = data.get('job_id')
 
         if data.get('error') is not None:
-            logging.error(f"Error returned by worker for series {data.get('name')}")
+            logging.error(
+                f"Error returned by worker for series {data.get('name')}")
             await cls.set_job_failed(job_id, data.get('error'))
+            return
+
+        job_type = data.get('job_type')
+        job = await cls.get_activated_job(job_id)
+        await cls.deactivate_job(job_id)
+        series = await SeriesManager.get_series(data.get('name'))
+        if job_type == JOB_TYPE_FORECAST_SERIES:
+            try:
+                await SeriesManager.add_forecast_to_series(
+                    data.get('name'), data.get('points'))
+                await series.set_job_status(
+                    job.job_config.link_name, JOB_STATUS_DONE)
+                await series.schedule_job(job.job_config.link_name)
+                await SeriesManager.series_changed(
+                    SUBSCRIPTION_CHANGE_TYPE_UPDATE, data.get('name'))
+            except Exception as e:
+                logging.error(
+                    f"Something went wrong when receiving forecast job")
+                logging.debug(f"Corresponding error: {e}")
+        elif job_type == JOB_TYPE_DETECT_ANOMALIES_FOR_SERIES:
+            if isinstance(
+                    data.get('anomalies'),
+                    list) and len(
+                    data.get('anomalies')) > 0:
+                try:
+                    await SeriesManager.add_anomalies_to_series(
+                        data.get('name'), data.get('anomalies'))
+                    await series.set_job_status(
+                        job.job_config.link_name, JOB_STATUS_DONE)
+                    await series.schedule_job(job.job_config.link_name)
+                    await SeriesManager.series_changed(
+                        SUBSCRIPTION_CHANGE_TYPE_UPDATE, data.get('name'))
+                except Exception as e:
+                    logging.error(
+                        f"Something went wrong when receiving \
+                            anomaly detection job")
+                    logging.debug(f"Corresponding error: {e}")
+        elif job_type == JOB_TYPE_BASE_SERIES_ANALYSIS:
+            try:
+                series.series_characteristics = data.get(
+                    'data').get('characteristics')
+                series.state.health = data.get('data').get('health')
+                await series.set_job_status(
+                    job.job_config.link_name, JOB_STATUS_DONE)
+                await series.schedule_job(job.job_config.link_name)
+                await SeriesManager.series_changed(
+                    SUBSCRIPTION_CHANGE_TYPE_UPDATE, data.get('name'))
+            except Exception as e:
+                logging.error(
+                    f"Something went wrong when receiving base analysis job")
+                logging.debug(f"Corresponding error: {e}")
+        elif job_type == JOB_TYPE_STATIC_RULES:
+            try:
+                await series.set_job_status(
+                    job.job_config.link_name, JOB_STATUS_DONE)
+                await series.schedule_job(job.job_config.link_name)
+                if len(data.get('failed_checks')):
+                    for key in data.get('failed_checks'):
+                        event = EnodoEvent(
+                            'Static rule failed!',
+                            f'Series {data.get("name")} failed a \
+                                static rule ({key}): \
+                                    {data.get("failed_checks")[key]}',
+                            ENODO_EVENT_STATIC_RULE_FAIL,
+                            series=series)
+                        await EnodoEventManager.handle_event(
+                            event, series=series)
+                await SeriesManager.series_changed(
+                    SUBSCRIPTION_CHANGE_TYPE_UPDATE, data.get('name'))
+            except Exception as e:
+                logging.error(
+                    f"Something went wrong when receiving static rules job")
+                logging.debug(f"Corresponding error: {e}")
         else:
-            job_type = data.get('job_type')
-            job = await cls.get_activated_job(job_id)
-            await cls.deactivate_job(job_id)
-            series = await SeriesManager.get_series(data.get('name'))
-            if job_type == JOB_TYPE_FORECAST_SERIES:
-                try:
-                    await SeriesManager.add_forecast_to_series(data.get('name'), data.get('points'))
-                    await series.set_job_status(job.job_config.link_name, JOB_STATUS_DONE)
-                    await series.schedule_job(job.job_config.link_name)
-                    await SeriesManager.series_changed(SUBSCRIPTION_CHANGE_TYPE_UPDATE, data.get('name'))
-                except Exception as e:
-                    logging.error(f"Something went wrong when receiving forecast job")
-                    logging.debug(f"Corresponding error: {e}")
-            elif job_type == JOB_TYPE_DETECT_ANOMALIES_FOR_SERIES:
-                if isinstance(data.get('anomalies'), list) and len(data.get('anomalies')) > 0:
-                    try:
-                        await SeriesManager.add_anomalies_to_series(data.get('name'), data.get('anomalies'))
-                        await series.set_job_status(job.job_config.link_name, JOB_STATUS_DONE)
-                        await series.schedule_job(job.job_config.link_name)
-                        await SeriesManager.series_changed(SUBSCRIPTION_CHANGE_TYPE_UPDATE, data.get('name'))
-                    except Exception as e:
-                        logging.error(f"Something went wrong when receiving anomaly detection job")
-                        logging.debug(f"Corresponding error: {e}")
-            elif job_type == JOB_TYPE_BASE_SERIES_ANALYSIS:
-                try:
-                    series.series_characteristics = data.get('data').get('characteristics')
-                    series.state.health = data.get('data').get('health')
-                    await series.set_job_status(job.job_config.link_name, JOB_STATUS_DONE)
-                    await series.schedule_job(job.job_config.link_name)
-                    await SeriesManager.series_changed(SUBSCRIPTION_CHANGE_TYPE_UPDATE, data.get('name'))
-                except Exception as e:
-                    logging.error(f"Something went wrong when receiving base analysis job")
-                    logging.debug(f"Corresponding error: {e}")
-            elif job_type == JOB_TYPE_STATIC_RULES:
-                try:
-                    await series.set_job_status(job.job_config.link_name, JOB_STATUS_DONE)
-                    await series.schedule_job(job.job_config.link_name)
-                    if len(data.get('failed_checks')):
-                        for key in data.get('failed_checks'):
-                            event = EnodoEvent('Static rule failed!',
-                                f'Series {data.get("name")} failed a static rule ({key}): {data.get("failed_checks")[key]}',
-                                ENODO_EVENT_STATIC_RULE_FAIL, series=series)
-                            await EnodoEventManager.handle_event(event, series=series)
-                    await SeriesManager.series_changed(SUBSCRIPTION_CHANGE_TYPE_UPDATE, data.get('name'))
-                except Exception as e:
-                    logging.error(f"Something went wrong when receiving static rules job")
-                    logging.debug(f"Corresponding error: {e}")
-            else:
-                logging.error(f"Received unknown job type: {job_type}")
+            logging.error(f"Received unknown job type: {job_type}")
 
     @classmethod
     async def _send_worker_job_request(cls, worker, job):
         try:
             series = await SeriesManager.get_series(job.series_name)
-            job_data = EnodoJobRequestDataModel(job_id=job.rid, \
-                                            job_config=job.job_config, \
-                                            series_name=job.series_name, \
-                                            series_config=series.series_config.to_dict())
+            job_data = EnodoJobRequestDataModel(
+                job_id=job.rid, job_config=job.job_config,
+                series_name=job.series_name,
+                series_config=series.series_config.to_dict())
             data = qpack.packb(job_data.serialize())
             header = create_header(len(data), WORKER_JOB, 0)
             worker.writer.write(header + data)
         except Exception as e:
-            logging.error(f"Something went wrong when sending job request to worker")
+            logging.error(
+                f"Something went wrong when sending job request to worker")
             import traceback
             traceback.print_exc()
             logging.debug(f"Corresponding error: {e}")
@@ -404,28 +452,35 @@ class EnodoJobManager:
         if worker is None:
             return
         try:
-            logging.error(f"Asking worker {worker_id} to cancel job {job_id}")
+            logging.error(
+                f"Asking worker {worker_id} to cancel job {job_id}")
             data = qpack.packb(
                 {'job_id': job_id})
             header = create_header(len(data), WORKER_JOB_CANCEL, 0)
             worker.writer.write(header + data)
         except Exception as e:
-            logging.error(f"Something went wrong when sending worker to cancel job")
+            logging.error(
+                f"Something went wrong when sending worker to cancel job")
             logging.debug(f"Corresponding error: {e}")
 
     @classmethod
-    async def receive_worker_cancelled_job(cls, writer, packet_type, packet_id, data, client_id):
+    async def receive_worker_cancelled_job(cls, writer, packet_type,
+                                           packet_id, data, client_id):
         job_id = data.get('job_id')
         worker = await ClientManager.get_worker_by_id(client_id)
         if job_id in cls._active_jobs_index:
-            await cls.set_job_failed(job_id, "Worker cancelled job. Check worker logging for details")
+            await cls.set_job_failed(
+                job_id,
+                "Worker cancelled job. Check worker logging for details")
         logging.error(f"Worker {client_id} cancelled job {job_id}")
         if worker is None:
             return
         try:
             await ClientManager.check_for_pending_series(worker)
         except Exception as e:
-            logging.error(f"Something went wrong when receiving from worker to cancel job")
+            logging.error(
+                f"Something went wrong when \
+                    receiving from worker to cancel job")
             logging.debug(f"Corresponding error: {e}")
 
     @classmethod
@@ -438,12 +493,13 @@ class EnodoJobManager:
         try:
             job_data = {
                 'next_job_id': cls._next_job_id,
-                # 'open_jobs': [EnodoJob.to_dict(job) for job in cls._open_jobs],
-                'failed_jobs': [EnodoJob.to_dict(job) for job in cls._failed_jobs],
+                'failed_jobs': [
+                    EnodoJob.to_dict(job) for job in cls._failed_jobs],
             }
             save_disk_data(Config.jobs_save_path, job_data)
         except Exception as e:
-            logging.error(f"Something went wrong when saving jobmanager data to disk")
+            logging.error(
+                f"Something went wrong when saving jobmanager data to disk")
             logging.debug(f"Corresponding error: {e}")
         cls._unlock()
 
@@ -457,13 +513,15 @@ class EnodoJobManager:
             data = load_disk_data(Config.jobs_save_path)
         except Exception as e:
             data = {}
-        
+
         if isinstance(data, dict):
             if 'next_job_id' in data:
                 cls._next_job_id = int(data.get('next_job_id'))
             if 'failed_jobs' in data:
                 loaded_failed_jobs += len(data.get('failed_jobs'))
-                cls._failed_jobs = [EnodoJob.from_dict(job_data) for job_data in data.get('failed_jobs')]
+                cls._failed_jobs = [
+                    EnodoJob.from_dict(job_data)
+                    for job_data in data.get('failed_jobs')]
 
         await cls._build_index()
 

--- a/lib/enodojobmanager.py
+++ b/lib/enodojobmanager.py
@@ -126,11 +126,11 @@ class EnodoJobManager:
     @classmethod
     async def create_job(cls, job_link_name, series_name):
         series = await SeriesManager.get_series(series_name)
+        await series.set_job_status(job_link_name, JOB_STATUS_OPEN)
         job_config = series.get_job(job_link_name)
         job_id = await cls._get_next_job_id()
         job = EnodoJob(job_id, series_name, job_config,
                        job_data=None)  # TODO: Catch exception
-        await series.set_job_status(job_link_name, JOB_STATUS_OPEN)
         await cls._add_job(job)
 
     @classmethod
@@ -329,14 +329,14 @@ class EnodoJobManager:
                         continue
 
                     logging.info(
-                        f"Adding series: sending {next_job.series_name} to \
-                            Worker for job type {next_job.job_config.job_type}")
+                        f"Adding series: sending {next_job.series_name} to "
+                        f"Worker for job type {next_job.job_config.job_type}")
                     await cls._send_worker_job_request(worker, next_job)
                     worker.is_going_busy = True
                     await cls._activate_job(next_job, worker.client_id)
                 except Exception as e:
                     logging.error(
-                        f"Something went wrong when trying to activate job")
+                        "Something went wrong when trying to activate job")
                     logging.debug(f"Corresponding error: {e}")
                 finally:
                     cls._unlock()
@@ -390,8 +390,8 @@ class EnodoJobManager:
                         SUBSCRIPTION_CHANGE_TYPE_UPDATE, data.get('name'))
                 except Exception as e:
                     logging.error(
-                        f"Something went wrong when receiving \
-                            anomaly detection job")
+                        f"Something went wrong when receiving"
+                        f"anomaly detection job")
                     logging.debug(f"Corresponding error: {e}")
         elif job_type == JOB_TYPE_BASE_SERIES_ANALYSIS:
             try:
@@ -483,8 +483,8 @@ class EnodoJobManager:
             await ClientManager.check_for_pending_series(worker)
         except Exception as e:
             logging.error(
-                f"Something went wrong when \
-                    receiving from worker to cancel job")
+                f"Something went wrong when"
+                f"receiving from worker to cancel job")
             logging.debug(f"Corresponding error: {e}")
 
     @classmethod

--- a/lib/enodojobmanager.py
+++ b/lib/enodojobmanager.py
@@ -361,7 +361,9 @@ class EnodoJobManager:
         if job_type == JOB_TYPE_FORECAST_SERIES:
             try:
                 await SeriesManager.add_forecast_to_series(
-                    data.get('name'), data.get('points'))
+                    data.get('name'),
+                    job.job_config.link_name,
+                    data.get('points'))
                 await series.set_job_status(
                     job.job_config.link_name, JOB_STATUS_DONE)
                 await series.schedule_job(job.job_config.link_name)
@@ -378,7 +380,9 @@ class EnodoJobManager:
                     data.get('anomalies')) > 0:
                 try:
                     await SeriesManager.add_anomalies_to_series(
-                        data.get('name'), data.get('anomalies'))
+                        data.get('name'),
+                        job.job_config.link_name,
+                        data.get('anomalies'))
                     await series.set_job_status(
                         job.job_config.link_name, JOB_STATUS_DONE)
                     await series.schedule_job(job.job_config.link_name)

--- a/lib/events/enodoeventmanager.py
+++ b/lib/events/enodoeventmanager.py
@@ -168,7 +168,9 @@ class EnodoEventOutputWebhook(EnodoEventOutput):
             except Exception as e:
                 logging.warning(
                     'Calling EnodoEventOutput webhook failed')
-                logging.debug(f'Corresponding error: {e}')
+                logging.debug(
+                    f'Corresponding error: {e}, '
+                    f'exception class: {e.__class__.__name__}')
 
     def update(self, data):
         self.url = data.get('url') if data.get(
@@ -319,7 +321,8 @@ class EnodoEventManager:
         except Exception as e:
             logging.error(
                 f"Something went wrong when writing eventmanager data to disk")
-            logging.debug(f"Corresponding error: {e}")
+            logging.debug(f"Corresponding error: {e}, "
+                          f'exception class: {e.__class__.__name__}')
 
 
 async def internal_updates_event_output_subscribers(change_type, data):

--- a/lib/events/enodoeventmanager.py
+++ b/lib/events/enodoeventmanager.py
@@ -3,9 +3,9 @@ import logging
 import time
 import os
 import uuid
-
-import aiohttp
 import json
+import aiohttp
+
 from jinja2 import Environment
 
 from lib.config import Config
@@ -39,8 +39,8 @@ ENODO_EVENT_SEVERITY_LEVELS = [
 
 class EnodoEvent:
     """
-    EnodoEvent class. Holds data for an event (error/warning/etc) that occured. 
-    No state data is saved.
+    EnodoEvent class. Holds data for an event (error/warning/etc) 
+    that occured. No state data is saved.
     """
     __slots__ = ('title', 'message', 'event_type',
                  'series_name', 'ts', 'severity', 'uuid')

--- a/lib/events/enodoeventmanager.py
+++ b/lib/events/enodoeventmanager.py
@@ -36,7 +36,7 @@ class EnodoEvent:
     """
     EnodoEvent class. Holds data for an event (error/warning/etc) that occured. No state data is saved.
     """
-    __slots__ = ('title', 'message', 'event_type', 'series', 'ts', 'severity', 'uuid')
+    __slots__ = ('title', 'message', 'event_type', 'series_name', 'ts', 'severity', 'uuid')
 
     def __init__(self, title, message, event_type, series=None):
         if event_type not in ENODO_EVENT_TYPES:
@@ -54,6 +54,7 @@ class EnodoEvent:
             'title': self.title,
             'event_type': self.event_type,
             'message': self.message,
+            'series_name': self.series_name,
             'ts': self.ts,
             'uuid': self.uuid
         }
@@ -246,10 +247,10 @@ class EnodoEventManager:
         await cls._unlock()
 
     @classmethod
-    async def handle_event(cls, event):
+    async def handle_event(cls, event, series=None):
         if isinstance(event, EnodoEvent):
             if event.event_type in ENODO_SERIES_RELATED_EVENT_TYPES:
-                if event.series is not None and event.series.series_config.silenced == True:
+                if series is not None and series.is_ignored() == True:
                     return False
             for output in cls.outputs:
                 await output.send_event(event)

--- a/lib/logging.py
+++ b/lib/logging.py
@@ -1,7 +1,8 @@
 import logging
 
-AVAILABLE_LOG_LEVELS = {'error': logging.ERROR, 'warning': logging.WARNING, 'info': logging.INFO,
-                        'debug': logging.DEBUG}
+AVAILABLE_LOG_LEVELS = {
+    'error': logging.ERROR, 'warning': logging.WARNING,
+    'info': logging.INFO, 'debug': logging.DEBUG}
 
 
 def prepare_logger(log_level_label):

--- a/lib/series/series.py
+++ b/lib/series/series.py
@@ -7,12 +7,14 @@ from enodo.model.config.series import SeriesConfigModel, SeriesState
 class Series:
     # detecting_anomalies_status forecast_status series_analysed_status
     __slots__ = (
-        'rid', 'name', 'series_config', 'series_state', '_datapoint_count_lock', 'series_characteristics')
+        'rid', 'name', 'series_config', 'state', '_datapoint_count_lock', 'series_characteristics')
 
-    def __init__(self, name, config, state, series_characteristics=None, **kwargs):
+    def __init__(self, name, config, state=None, series_characteristics=None, **kwargs):
         self.rid = name
         self.name = name
         self.series_config = SeriesConfigModel.from_dict(config)
+        if state is None:
+            state = {}
         self.state = SeriesState.from_dict(state)
         self.series_characteristics = series_characteristics
 
@@ -118,24 +120,24 @@ class Series:
         if static_only:
             return {
                 'name': self.name,
-                'datapoint_count': self._datapoint_count,
-                'job_statuses': self.series_job_statuses,
-                'job_schedule': self._job_schedule,
+                'datapoint_count': self.state.datapoint_count,
+                'job_statuses': self.state.job_schedule.to_dict(),
+                'job_schedule': self.state.job_schedule.to_dict(),
                 'config': self.series_config.to_dict(),
                 'series_characteristics': self.series_characteristics,
-                'health': self.health
+                'health': self.state.health
             }
         return {
             'rid': self.rid,
             'name': self.name,
-            'datapoint_count': self._datapoint_count,
-            'job_statuses': self.series_job_statuses,
-            'job_schedule': self._job_schedule,
+            'datapoint_count': self.state.datapoint_count,
+            'job_statuses': self.state.job_statuses.to_dict(),
+            'job_schedule': self.state.job_schedule.to_dict(),
             'config': self.series_config.to_dict(),
             'ignore': self.is_ignored(),
             'error': self.get_errors(),
             'series_characteristics': self.series_characteristics,
-            'health': self.health
+            'health': self.state.health
         }
 
     @classmethod

--- a/lib/series/series.py
+++ b/lib/series/series.py
@@ -48,11 +48,11 @@ class Series:
     async def get_model(self, job_name):
         return self.series_config.get_config_for_job(job_name).model
 
-    async def get_job_status(self, job_link_name):
-        return self.state.get_job_status(job_link_name)
+    async def get_job_status(self, job_config_name):
+        return self.state.get_job_status(job_config_name)
 
-    async def set_job_status(self, link_name, status):
-        self.state.set_job_status(link_name, status)
+    async def set_job_status(self, config_name, status):
+        self.state.set_job_status(config_name, status)
 
     @property
     def base_analysis_job(self):
@@ -62,15 +62,15 @@ class Series:
             return False
         return job_config
 
-    def get_job(self, job_link_name):
-        return self.series_config.get_config_for_job(job_link_name)
+    def get_job(self, job_config_name):
+        return self.series_config.get_config_for_job(job_config_name)
 
     def base_analysis_status(self):
         job_config = self.series_config.get_config_for_job_type(
             JOB_TYPE_BASE_SERIES_ANALYSIS)
         if job_config is None or job_config is False:
             return False
-        return self.state.get_job_status(job_config.link_name)
+        return self.state.get_job_status(job_config.config_name)
 
     def get_datapoints_count(self):
         return self.state.datapoint_count
@@ -84,13 +84,13 @@ class Series:
         if self._datapoint_count_lock is False:
             self.state.datapoint_count += add_to_count
 
-    async def schedule_job(self, job_link_name, initial=False):
+    async def schedule_job(self, job_config_name, initial=False):
         job_config = self.series_config.get_config_for_job(
-            job_link_name)
+            job_config_name)
         if job_config is None:
             return False
 
-        job_schedule = self.state.get_job_schedule(job_link_name)
+        job_schedule = self.state.get_job_schedule(job_config_name)
 
         if job_schedule is None:
             job_schedule = {"value": 0,
@@ -112,15 +112,15 @@ class Series:
 
         if next_value is not None:
             job_schedule['value'] = next_value
-            self.state.set_job_schedule(job_link_name, job_schedule)
+            self.state.set_job_schedule(job_config_name, job_schedule)
 
-    async def is_job_due(self, job_link_name):
-        job_status = self.state.get_job_status(job_link_name)
-        job_schedule = self.state.get_job_schedule(job_link_name)
+    async def is_job_due(self, job_config_name):
+        job_status = self.state.get_job_status(job_config_name)
+        job_schedule = self.state.get_job_schedule(job_config_name)
 
         if job_status == JOB_STATUS_NONE or job_status == JOB_STATUS_DONE:
             job_config = self.series_config.get_config_for_job(
-                job_link_name)
+                job_config_name)
             if job_config.requires_job is not None:
                 required_job_status = self.state.get_job_status(
                     job_config.requires_job)

--- a/lib/series/series.py
+++ b/lib/series/series.py
@@ -128,10 +128,10 @@ class Series:
                     return False
             if job_schedule["value"] is None:
                 return True
-            elif job_schedule["type"] == "TS" and \
+            if job_schedule["type"] == "TS" and \
                 job_schedule["value"] <= int(time.time()):
                 return True
-            elif job_schedule["type"] == "N" and \
+            if job_schedule["type"] == "N" and \
                 job_schedule["value"] <= self.state.datapoint_count:
                 return True
         return False

--- a/lib/series/seriesmanager.py
+++ b/lib/series/seriesmanager.py
@@ -238,4 +238,5 @@ class SeriesManager:
             logging.error(
                 f"Something went wrong when writing "
                 f"seriesmanager data to disk")
-            logging.debug(f"Corresponding error: {e}")
+            logging.debug(f"Corresponding error: {e}, "
+                          f'exception class: {e.__class__.__name__}')

--- a/lib/series/seriesmanager.py
+++ b/lib/series/seriesmanager.py
@@ -150,36 +150,37 @@ class SeriesManager:
         series = cls._series.get(series_name, None)
         if series is not None:
             await series.add_to_datapoints_count(value)
-        elif series_name not in cls._series and \
-                series_name in Config.names_enabled_series_for_analysis:
+        elif series_name not in cls._series:
             await cls.add_series(series_name)
 
     @classmethod
-    async def add_forecast_to_series(cls, series_name, points):
+    async def add_forecast_to_series(cls, series_name,
+                                     job_config_name, points):
         series = cls._series.get(series_name, None)
         if series is not None:
             await drop_series(
                 ServerState.get_siridb_forecast_conn(),
-                f'forecast_{series_name}')
+                f'enodo_{series_name}_forecast_{job_config_name}')
             await insert_points(
                 ServerState.get_siridb_forecast_conn(),
-                f'forecast_{series_name}', points)
+                f'enodo_{series_name}_forecast_{job_config_name}', points)
 
     @classmethod
-    async def add_anomalies_to_series(cls, series_name, points):
+    async def add_anomalies_to_series(cls, series_name, job_config_name, points):
         series = cls._series.get(series_name, None)
         if series is not None:
             event = EnodoEvent(
                 'Anomaly detected!',
-                f'{len(points)} anomalies detected for series {series_name}',
+                f'{len(points)} anomalies detected for series {series_name} \
+                    via job {job_config_name}',
                 ENODO_EVENT_ANOMALY_DETECTED, series=series)
             await EnodoEventManager.handle_event(event)
             await drop_series(
                 ServerState.get_siridb_forecast_conn(),
-                f'anomalies_{series_name}')
+                f'enodo_{series_name}_anomalies_{job_config_name}')
             await insert_points(
                 ServerState.get_siridb_forecast_conn(),
-                f'anomalies_{series_name}', points)
+                f'enodo_{series_name}_anomalies_{job_config_name}', points)
 
     @classmethod
     async def get_series_forecast(cls, series_name):

--- a/lib/series/seriesmanager.py
+++ b/lib/series/seriesmanager.py
@@ -21,8 +21,7 @@ from lib.socketio import SUBSCRIPTION_CHANGE_TYPE_ADD,\
 from lib.util import load_disk_data, save_disk_data
 
 from enodo.jobs import JOB_STATUS_DONE, JOB_TYPE_BASE_SERIES_ANALYSIS,\
-    JOB_TYPE_DETECT_ANOMALIES_FOR_SERIES, JOB_TYPE_FORECAST_SERIES,\
-    JOB_TYPE_DETECT_ANOMALIES_FOR_SERIES_REALTIME
+    JOB_TYPE_DETECT_ANOMALIES_FOR_SERIES, JOB_TYPE_FORECAST_SERIES
 
 
 class SeriesManager:
@@ -141,7 +140,6 @@ class SeriesManager:
         if series is not None:
             await drop_series(ServerState.get_siridb_forecast_conn(), f'forecast_{series_name}')
             await insert_points(ServerState.get_siridb_forecast_conn(), f'forecast_{series_name}', points)
-            await series.set_job_status(JOB_TYPE_FORECAST_SERIES, JOB_STATUS_DONE)
 
             # date_1 = datetime.datetime.now()
             # # end_date = date_1 + datetime.timedelta(days=1)
@@ -153,11 +151,10 @@ class SeriesManager:
         series = cls._series.get(series_name, None)
         if series is not None:
             event = EnodoEvent('Anomaly detected!', f'{len(points)} anomalies detected for series {series_name}',
-                               ENODO_EVENT_ANOMALY_DETECTED)
+                               ENODO_EVENT_ANOMALY_DETECTED, series=series)
             await EnodoEventManager.handle_event(event)
             await drop_series(ServerState.get_siridb_forecast_conn(), f'anomalies_{series_name}')
             await insert_points(ServerState.get_siridb_forecast_conn(), f'anomalies_{series_name}', points)
-            await series.set_job_status(JOB_TYPE_DETECT_ANOMALIES_FOR_SERIES, JOB_STATUS_DONE)
 
     @classmethod
     async def get_series_forecast(cls, series_name):

--- a/lib/series/seriesmanager.py
+++ b/lib/series/seriesmanager.py
@@ -51,8 +51,10 @@ class SeriesManager:
             if await does_series_exist(ServerState.get_siridb_data_conn(), series.get('name')):
                 collected_datapoints = await query_series_datapoint_count(ServerState.get_siridb_data_conn(), series.get('name'))
                 if collected_datapoints:
-                    series['datapoint_count'] = collected_datapoints
+
+                    # series['datapoint_count'] = collected_datapoints
                     cls._series[series.get('name')] = Series.from_dict(series)
+                    cls._series[series.get('name')].state.datapoint_count = collected_datapoints
                     logging.info(f"Added new series: {series.get('name')}")
                     await cls.series_changed(SUBSCRIPTION_CHANGE_TYPE_ADD, series.get('name'))
                     await cls.update_listeners(cls.get_listener_series_info())

--- a/lib/series/seriesmanager.py
+++ b/lib/series/seriesmanager.py
@@ -236,5 +236,6 @@ class SeriesManager:
             save_disk_data(Config.series_save_path, serialized_data)
         except Exception as e:
             logging.error(
-                f"Something went wrong when writing seriesmanager data to disk")
+                f"Something went wrong when writing "
+                f"seriesmanager data to disk")
             logging.debug(f"Corresponding error: {e}")

--- a/lib/series/seriesmanager.py
+++ b/lib/series/seriesmanager.py
@@ -1,5 +1,4 @@
-import datetime
-import json
+from lib.series.series import Series
 import logging
 import os
 import re
@@ -20,21 +19,16 @@ from lib.socketio import SUBSCRIPTION_CHANGE_TYPE_ADD,\
     SUBSCRIPTION_CHANGE_TYPE_DELETE
 from lib.util import load_disk_data, save_disk_data
 
-from enodo.jobs import JOB_STATUS_DONE, JOB_TYPE_BASE_SERIES_ANALYSIS,\
-    JOB_TYPE_DETECT_ANOMALIES_FOR_SERIES, JOB_TYPE_FORECAST_SERIES
-
 
 class SeriesManager:
-    _series = None
-    _labels = None
+    _series = {}
+    _labels = {}
     _labels_last_update = None
     _update_cb = None
 
     @classmethod
     async def prepare(cls, update_cb=None):
-        cls._series = {}
         cls._update_cb = update_cb
-        cls._labels = {}
         cls._labels_last_update = None
 
     @classmethod
@@ -43,22 +37,30 @@ class SeriesManager:
             if change_type == "delete":
                 await cls._update_cb(change_type, series_name, series_name)
             else:
-                await cls._update_cb(change_type, (await cls.get_series(series_name)).to_dict(), series_name)
+                await cls._update_cb(
+                    change_type,
+                    (await cls.get_series(series_name)).to_dict(),
+                    series_name)
 
     @classmethod
     async def add_series(cls, series):
-        if series.get('name') not in cls._series:
-            if await does_series_exist(ServerState.get_siridb_data_conn(), series.get('name')):
-                collected_datapoints = await query_series_datapoint_count(ServerState.get_siridb_data_conn(), series.get('name'))
-                if collected_datapoints:
-
-                    # series['datapoint_count'] = collected_datapoints
-                    cls._series[series.get('name')] = Series.from_dict(series)
-                    cls._series[series.get('name')].state.datapoint_count = collected_datapoints
-                    logging.info(f"Added new series: {series.get('name')}")
-                    await cls.series_changed(SUBSCRIPTION_CHANGE_TYPE_ADD, series.get('name'))
-                    await cls.update_listeners(cls.get_listener_series_info())
-                    return True
+        if series.get('name') in cls._series:
+            return False
+        if await does_series_exist(
+                ServerState.get_siridb_data_conn(), series.get('name')):
+            collected_datapoints = await query_series_datapoint_count(
+                ServerState.get_siridb_data_conn(), series.get('name'))
+            if collected_datapoints:
+                cls._series[series.get(
+                    'name')] = Series.from_dict(series)
+                cls._series[series.get(
+                    'name')].state.datapoint_count = collected_datapoints
+                logging.info(
+                    f"Added new series: {series.get('name')}")
+                await cls.series_changed(
+                    SUBSCRIPTION_CHANGE_TYPE_ADD, series.get('name'))
+                await cls.update_listeners(cls.get_listener_series_info())
+                return True
         return False
 
     @classmethod
@@ -74,8 +76,14 @@ class SeriesManager:
 
     @classmethod
     def get_listener_series_info(cls):
-        series = [{"name": series_name, "realtime": series.series_config.realtime} for series_name, series in cls._series.items()]
-        labels = [{"name": label.get('selector'), "realtime": label.get('series_config').get('realtime'), "isGroup": label.get('type') == "group"} for label in cls._labels.values()]
+        series = [{"name": series_name,
+                   "realtime": series.series_config.realtime}
+                  for series_name, series in cls._series.items()]
+        labels = [
+            {"name": label.get('selector'),
+             "realtime": label.get('series_config').get('realtime'),
+             "isGroup": label.get('type') == "group"}
+            for label in cls._labels.values()]
         return series + labels
 
     @classmethod
@@ -92,9 +100,14 @@ class SeriesManager:
     @classmethod
     async def add_label(cls, description, name, series_config):
         if name not in cls._labels:
-            # TODO: Change auto type == "group" to a input value when tags are added
-            group_expression = await query_group_expression_by_name(ServerState.get_siridb_data_conn(), name)
-            cls._labels[name] = {"description": description, "name": name, "series_config": series_config, "type": "group", "selector": group_expression}
+            # TODO: Change auto type == "group" to a input value
+            # when tags are added
+            group_expression = await query_group_expression_by_name(
+                ServerState.get_siridb_data_conn(), name)
+            cls._labels[name] = {
+                "description": description, "name": name,
+                "series_config": series_config, "type": "group",
+                "selector": group_expression}
             cls._update_listeners()
 
     @classmethod
@@ -111,19 +124,23 @@ class SeriesManager:
 
     @classmethod
     def get_ignored_series_count(cls):
-        return len([cls._series[rid] for rid in cls._series if cls._series[rid].is_ignored is True])
+        return len([cls._series[rid] for rid in cls._series
+                    if cls._series[rid].is_ignored is True])
 
     @classmethod
     async def get_series_to_dict(cls, regex_filter=None):
         if regex_filter is not None:
             pattern = re.compile(regex_filter)
-            return [series.to_dict() for series in cls._series.values() if pattern.match(series.name)]
+            return [
+                series.to_dict() for series in cls._series.values() if
+                pattern.match(series.name)]
         return [series.to_dict() for series in cls._series.values()]
 
     @classmethod
     async def remove_series(cls, series_name):
-        if series_name in cls._series:            
-            await cls.series_changed(SUBSCRIPTION_CHANGE_TYPE_DELETE, series_name)
+        if series_name in cls._series:
+            await cls.series_changed(
+                SUBSCRIPTION_CHANGE_TYPE_DELETE, series_name)
             del cls._series[series_name]
             return True
         return False
@@ -133,41 +150,49 @@ class SeriesManager:
         series = cls._series.get(series_name, None)
         if series is not None:
             await series.add_to_datapoints_count(value)
-        elif series_name not in cls._series and series_name in Config.names_enabled_series_for_analysis:
+        elif series_name not in cls._series and \
+                series_name in Config.names_enabled_series_for_analysis:
             await cls.add_series(series_name)
 
     @classmethod
     async def add_forecast_to_series(cls, series_name, points):
         series = cls._series.get(series_name, None)
         if series is not None:
-            await drop_series(ServerState.get_siridb_forecast_conn(), f'forecast_{series_name}')
-            await insert_points(ServerState.get_siridb_forecast_conn(), f'forecast_{series_name}', points)
-
-            # date_1 = datetime.datetime.now()
-            # # end_date = date_1 + datetime.timedelta(days=1)
-            # end_date = date_1 + datetime.timedelta(seconds=Config.interval_schedules_series)
-            # await series.schedule_forecast(end_date)
+            await drop_series(
+                ServerState.get_siridb_forecast_conn(),
+                f'forecast_{series_name}')
+            await insert_points(
+                ServerState.get_siridb_forecast_conn(),
+                f'forecast_{series_name}', points)
 
     @classmethod
     async def add_anomalies_to_series(cls, series_name, points):
         series = cls._series.get(series_name, None)
         if series is not None:
-            event = EnodoEvent('Anomaly detected!', f'{len(points)} anomalies detected for series {series_name}',
-                               ENODO_EVENT_ANOMALY_DETECTED, series=series)
+            event = EnodoEvent(
+                'Anomaly detected!',
+                f'{len(points)} anomalies detected for series {series_name}',
+                ENODO_EVENT_ANOMALY_DETECTED, series=series)
             await EnodoEventManager.handle_event(event)
-            await drop_series(ServerState.get_siridb_forecast_conn(), f'anomalies_{series_name}')
-            await insert_points(ServerState.get_siridb_forecast_conn(), f'anomalies_{series_name}', points)
+            await drop_series(
+                ServerState.get_siridb_forecast_conn(),
+                f'anomalies_{series_name}')
+            await insert_points(
+                ServerState.get_siridb_forecast_conn(),
+                f'anomalies_{series_name}', points)
 
     @classmethod
     async def get_series_forecast(cls, series_name):
-        values = await query_series_data(ServerState.get_siridb_forecast_conn(), f'forecast_{series_name}')
+        values = await query_series_data(
+            ServerState.get_siridb_forecast_conn(), f'forecast_{series_name}')
         if values is not None:
             return values.get(f'forecast_{series_name}', None)
         return None
 
     @classmethod
     async def get_series_anomalies(cls, series_name):
-        values = await query_series_data(ServerState.get_siridb_forecast_conn(), f'anomalies_{series_name}')
+        values = await query_series_data(
+            ServerState.get_siridb_forecast_conn(), f'anomalies_{series_name}')
         if values is not None:
             return values.get(f'anomalies_{series_name}', None)
         return None
@@ -199,7 +224,8 @@ class SeriesManager:
         try:
             serialized_series = []
             for series in cls._series.values():
-                serialized_series.append(series.to_dict(static_only=True))
+                serialized_series.append(
+                    series.to_dict(static_only=True))
             serialized_labels = list(cls._labels.values())
 
             serialized_data = {
@@ -208,7 +234,6 @@ class SeriesManager:
             }
             save_disk_data(Config.series_save_path, serialized_data)
         except Exception as e:
-            logging.error(f"Something went wrong when writing seriesmanager data to disk")
+            logging.error(
+                f"Something went wrong when writing seriesmanager data to disk")
             logging.debug(f"Corresponding error: {e}")
-
-from lib.series.series import Series

--- a/lib/siridb/siridb.py
+++ b/lib/siridb/siridb.py
@@ -1,13 +1,15 @@
-from siridb.connector.lib.exceptions import QueryError, InsertError, ServerError, PoolError, AuthenticationError, \
-    UserAuthError
+from siridb.connector.lib.exceptions import QueryError, InsertError, \
+    ServerError, PoolError, AuthenticationError, UserAuthError
 
 
 # @classmethod
 async def query_series_datapoint_count(siridb_client, series_name):
     count = None
     try:
-        result = await siridb_client.query(f'select count() from "{series_name}"')
-    except (QueryError, InsertError, ServerError, PoolError, AuthenticationError, UserAuthError) as e:
+        result = await siridb_client.query(
+            f'select count() from "{series_name}"')
+    except (QueryError, InsertError, ServerError, PoolError,
+            AuthenticationError, UserAuthError) as e:
         print(e)
         print("Connection problem with SiriDB server")
         pass
@@ -19,10 +21,12 @@ async def query_series_datapoint_count(siridb_client, series_name):
 async def does_series_exist(siridb_client, series_name):
     exists = False
     try:
-        result = await siridb_client.query(f'select count() from "{series_name}"')
+        result = await siridb_client.query(
+            f'select count() from "{series_name}"')
         if result.get(series_name) is not None:
             exists = True
-    except (QueryError, InsertError, ServerError, PoolError, AuthenticationError, UserAuthError) as e:
+    except (QueryError, InsertError, ServerError, PoolError,
+            AuthenticationError, UserAuthError) as e:
         print("Connection problem with SiriDB server")
         pass
     return exists
@@ -32,8 +36,10 @@ async def does_series_exist(siridb_client, series_name):
 async def query_series_data(siridb_client, series_name, selector="*"):
     result = None
     try:
-        result = await siridb_client.query(f'select {selector} from "{series_name}"')
-    except (QueryError, InsertError, ServerError, PoolError, AuthenticationError, UserAuthError) as e:
+        result = await siridb_client.query(
+            f'select {selector} from "{series_name}"')
+    except (QueryError, InsertError, ServerError, PoolError,
+            AuthenticationError, UserAuthError) as e:
         print("Connection problem with SiriDB server")
         pass
     return result
@@ -43,7 +49,8 @@ async def drop_series(siridb_client, series_name):
     result = None
     try:
         result = await siridb_client.query(f'drop series "{series_name}"')
-    except (QueryError, InsertError, ServerError, PoolError, AuthenticationError, UserAuthError) as e:
+    except (QueryError, InsertError, ServerError, PoolError,
+            AuthenticationError, UserAuthError) as e:
         print("Connection problem with SiriDB server")
         pass
     return result
@@ -53,17 +60,21 @@ async def insert_points(siridb_client, series_name, points):
     result = None
     try:
         await siridb_client.insert({series_name: points})
-    except (QueryError, InsertError, ServerError, PoolError, AuthenticationError, UserAuthError) as e:
+    except (QueryError, InsertError, ServerError, PoolError,
+            AuthenticationError, UserAuthError) as e:
         print("Connection problem with SiriDB server")
         print(e)
         pass
     return result
 
+
 async def query_group_expression_by_name(siridb_client, group_name):
     result = None
     try:
-        result = await siridb_client.query(f'list groups where name == "{group_name}"')
-    except (QueryError, InsertError, ServerError, PoolError, AuthenticationError, UserAuthError) as e:
+        result = await siridb_client.query(
+            f'list groups where name == "{group_name}"')
+    except (QueryError, InsertError, ServerError, PoolError,
+            AuthenticationError, UserAuthError) as e:
         print("Connection problem with SiriDB server")
         pass
     groups = result.get('groups')

--- a/lib/siridb/siridb.py
+++ b/lib/siridb/siridb.py
@@ -103,7 +103,7 @@ async def query_series_anomalies(siridb_client, series_name, selector="*"):
     result = None
     try:
         result = await siridb_client.query(
-            f'select {selector} from /enodo_{series_name}_anomalies_*/')
+            f'select {selector} from /enodo_{re.escape(series_name)}_anomalies_*?$/')
     except (QueryError, InsertError, ServerError, PoolError,
             AuthenticationError, UserAuthError) as e:
         print("Connection problem with SiriDB server")
@@ -116,7 +116,7 @@ async def query_series_static_rules_hits(
     result = None
     try:
         result = await siridb_client.query(
-            f'select {selector} from /enodo_{series_name}_static_rules_*/')
+            f'select {selector} from /enodo_{re.escape(series_name)}_static_rules_*?$/')
     except (QueryError, InsertError, ServerError, PoolError,
             AuthenticationError, UserAuthError) as e:
         print("Connection problem with SiriDB server")

--- a/lib/siridb/siridb.py
+++ b/lib/siridb/siridb.py
@@ -1,5 +1,8 @@
+import re
+
 from siridb.connector.lib.exceptions import QueryError, InsertError, \
     ServerError, PoolError, AuthenticationError, UserAuthError
+
 
 
 # @classmethod
@@ -88,7 +91,7 @@ async def query_series_forecasts(siridb_client, series_name, selector="*"):
     result = None
     try:
         result = await siridb_client.query(
-            f'select {selector} from \enodo_{series_name}_forecast_*\\')
+            f'select {selector} from /enodo_{re.escape(series_name)}_forecast_.*?$/')
     except (QueryError, InsertError, ServerError, PoolError,
             AuthenticationError, UserAuthError) as e:
         print("Connection problem with SiriDB server")
@@ -100,7 +103,7 @@ async def query_series_anomalies(siridb_client, series_name, selector="*"):
     result = None
     try:
         result = await siridb_client.query(
-            f'select {selector} from \enodo_{series_name}_anomalies_*\\')
+            f'select {selector} from /enodo_{series_name}_anomalies_*/')
     except (QueryError, InsertError, ServerError, PoolError,
             AuthenticationError, UserAuthError) as e:
         print("Connection problem with SiriDB server")
@@ -113,7 +116,7 @@ async def query_series_static_rules_hits(
     result = None
     try:
         result = await siridb_client.query(
-            f'select {selector} from \enodo_{series_name}_static_rules_*\\')
+            f'select {selector} from /enodo_{series_name}_static_rules_*/')
     except (QueryError, InsertError, ServerError, PoolError,
             AuthenticationError, UserAuthError) as e:
         print("Connection problem with SiriDB server")

--- a/lib/siridb/siridb.py
+++ b/lib/siridb/siridb.py
@@ -82,3 +82,40 @@ async def query_group_expression_by_name(siridb_client, group_name):
         return None
 
     return groups[0][0]
+
+
+async def query_series_forecasts(siridb_client, series_name, selector="*"):
+    result = None
+    try:
+        result = await siridb_client.query(
+            f'select {selector} from \enodo_{series_name}_forecast_*\\')
+    except (QueryError, InsertError, ServerError, PoolError,
+            AuthenticationError, UserAuthError) as e:
+        print("Connection problem with SiriDB server")
+        pass
+    return result
+
+
+async def query_series_anomalies(siridb_client, series_name, selector="*"):
+    result = None
+    try:
+        result = await siridb_client.query(
+            f'select {selector} from \enodo_{series_name}_anomalies_*\\')
+    except (QueryError, InsertError, ServerError, PoolError,
+            AuthenticationError, UserAuthError) as e:
+        print("Connection problem with SiriDB server")
+        pass
+    return result
+
+
+async def query_series_static_rules_hits(
+        siridb_client, series_name, selector="*"):
+    result = None
+    try:
+        result = await siridb_client.query(
+            f'select {selector} from \enodo_{series_name}_static_rules_*\\')
+    except (QueryError, InsertError, ServerError, PoolError,
+            AuthenticationError, UserAuthError) as e:
+        print("Connection problem with SiriDB server")
+        pass
+    return result

--- a/lib/socket/clientmanager.py
+++ b/lib/socket/clientmanager.py
@@ -2,7 +2,8 @@ import datetime
 import logging
 
 from enodo import WorkerConfigModel
-from enodo.model.config.worker import WORKER_MODE_GLOBAL, WORKER_MODE_DEDICATED_JOB_TYPE, \
+from enodo.model.config.worker import WORKER_MODE_GLOBAL, \
+    WORKER_MODE_DEDICATED_JOB_TYPE, \
     WORKER_MODE_DEDICATED_SERIES
 from enodo.jobs import JOB_STATUS_OPEN
 from enodo import EnodoModel
@@ -12,11 +13,13 @@ from lib.analyser.model import EnodoModelManager
 from lib.events.enodoeventmanager import EnodoEvent, EnodoEventManager, \
     ENODO_EVENT_LOST_CLIENT_WITHOUT_GOODBYE
 from .package import *
-    
+
 
 class EnodoClient:
 
-    def __init__(self, client_id, ip_address, writer, version="unknown", last_seen=None, online=True):
+    def __init__(
+            self, client_id, ip_address, writer, version="unknown",
+            last_seen=None, online=True):
         self.client_id = client_id
         self.ip_address = ip_address
         self.writer = writer
@@ -41,20 +44,30 @@ class EnodoClient:
 
 
 class ListenerClient(EnodoClient):
-    def __init__(self, client_id, ip_address, writer, version="unknown", last_seen=None):
+    def __init__(
+            self, client_id, ip_address, writer, version="unknown",
+            last_seen=None):
         super().__init__(client_id, ip_address, writer, version, last_seen)
 
 
 class WorkerClient(EnodoClient):
-    def __init__(self, client_id, ip_address, writer, supported_models, version="unknown", last_seen=None, busy=False, worker_config=None):
+    def __init__(
+            self, client_id, ip_address, writer, supported_models,
+            version="unknown", last_seen=None, busy=False,
+            worker_config=None):
         super().__init__(client_id, ip_address, writer, version, last_seen)
         self.busy = busy
         self.is_going_busy = False
-        supported_models = [EnodoModel.from_dict(model_data) for model_data in supported_models]
-        self.supported_models = {model.name: model for model in supported_models}
+        supported_models = [
+            EnodoModel.from_dict(model_data)
+            for model_data in supported_models]
+        self.supported_models = {model.name: model
+                                 for model in supported_models}
 
         if worker_config is None:
-            worker_config = WorkerConfigModel(WORKER_MODE_GLOBAL, dedicated_job_type=None, dedicated_series_name=None)
+            worker_config = WorkerConfigModel(
+                WORKER_MODE_GLOBAL, dedicated_job_type=None,
+                dedicated_series_name=None)
         self.worker_config = worker_config
 
     def support_model_for_job(self, job_type, model_name):
@@ -103,7 +116,9 @@ class ClientManager:
 
     @classmethod
     def get_busy_worker_count(cls):
-        busy_workers = [cls.workers[worker_id] for worker_id in cls.workers if cls.workers[worker_id].busy is True]
+        busy_workers = [cls.workers[worker_id]
+                        for worker_id in cls.workers
+                        if cls.workers[worker_id].busy is True]
         return len(busy_workers)
 
     @classmethod
@@ -116,14 +131,19 @@ class ClientManager:
                 continue
             if w.worker_config.mode == WORKER_MODE_DEDICATED_SERIES:
                 if cls._dedicated_for_series[w.worker_config.series] is None:
-                    cls._dedicated_for_series[w.worker_config.series] = [worker_id]
+                    cls._dedicated_for_series[w.worker_config.series] = [
+                        worker_id]
                 else:
-                    cls._dedicated_for_series[w.worker_config.series].append(worker_id)
+                    cls._dedicated_for_series[w.worker_config.series].append(
+                        worker_id)
             elif w.worker_config.mode == WORKER_MODE_DEDICATED_JOB_TYPE:
-                if cls._dedicated_for_job_type[w.worker_config.job_type] is None:
-                    cls._dedicated_for_job_type[w.worker_config.job_type] = [worker_id]
+                if cls._dedicated_for_job_type[
+                        w.worker_config.job_type] is None:
+                    cls._dedicated_for_job_type[w.worker_config.job_type] = [
+                        worker_id]
                 else:
-                    cls._dedicated_for_job_type[w.worker_config.job_type].append(worker_id)
+                    cls._dedicated_for_job_type[
+                        w.worker_config.job_type].append(worker_id)
 
     @classmethod
     async def listener_connected(cls, peername, writer, client_data):
@@ -140,9 +160,9 @@ class ClientManager:
         client_id = client_data.get('client_id')
         if client_id not in cls.workers:
             client = WorkerClient(client_id, peername, writer,
-                                    client_data.get('models'),
-                                    client_data.get('version', None),
-                                    busy=client_data.get('busy', None))
+                                  client_data.get('models'),
+                                  client_data.get('version', None),
+                                  busy=client_data.get('busy', None))
             await cls.add_client(client)
         else:
             await cls.workers.get(client_id).reconnected(peername, writer)
@@ -153,7 +173,8 @@ class ClientManager:
             cls.listeners[client.client_id] = client
         elif isinstance(client, WorkerClient):
             for model_name in client.supported_models:
-                await EnodoModelManager.add_enodo_model(client.supported_models[model_name])
+                await EnodoModelManager.add_enodo_model(
+                    client.supported_models[model_name])
             cls.workers[client.client_id] = client
             await cls._refresh_dedicated_cache()
 
@@ -184,7 +205,8 @@ class ClientManager:
             for worker_id in cls._dedicated_for_series[series_name]:
                 worker = cls.workers.get(worker_id)
                 if not worker.busy and not worker.is_going_busy:
-                    if worker.support_model_for_job(job_type, model_name):
+                    if worker.support_model_for_job(
+                            job_type, model_name):
                         return worker
 
         # Check if there is a worker free that's dedicated for the job_type
@@ -192,12 +214,14 @@ class ClientManager:
             for worker_id in cls._dedicated_for_series[job_type]:
                 worker = cls.workers.get(worker_id)
                 if not worker.busy and not worker.is_going_busy:
-                    if worker.support_model_for_job(job_type, model_name):
+                    if worker.support_model_for_job(
+                            job_type, model_name):
                         return worker
 
-        for worker_id in cls.workers: 
+        for worker_id in cls.workers:
             worker = cls.workers.get(worker_id)
-            if worker.worker_config.mode == WORKER_MODE_GLOBAL and not worker.busy and not worker.is_going_busy:
+            if worker.worker_config.mode == WORKER_MODE_GLOBAL and \
+                    not worker.busy and not worker.is_going_busy:
                 if worker.support_model_for_job(job_type, model_name):
                     return worker
 
@@ -210,7 +234,6 @@ class ClientManager:
             if listener.online:
                 cls.update_listener(listener, data)
 
-
     @classmethod
     def update_listener(cls, listener, data):
         update = qpack.packb(data)
@@ -221,7 +244,8 @@ class ClientManager:
     async def check_clients_alive(cls, max_timeout):
         for client in cls.listeners:
             listener = cls.listeners.get(client)
-            if listener.online and (datetime.datetime.now() - listener.last_seen) \
+            if listener.online and \
+                (datetime.datetime.now() - listener.last_seen) \
                     .total_seconds() > max_timeout:
                 logging.info(f'Lost connection to listener: {client}')
                 listener.online = False
@@ -255,19 +279,25 @@ class ClientManager:
             return
 
         if client.online:
-            logging.error(f'Client {client_id} went offline without goodbye')
+            logging.error(
+                f'Client {client_id} went offline without goodbye')
             client.online = False
-            event = EnodoEvent('Lost client', f'Client {client_id} went offline without goodbye',
-                               ENODO_EVENT_LOST_CLIENT_WITHOUT_GOODBYE)
+            event = EnodoEvent(
+                'Lost client',
+                f'Client {client_id} went offline without goodbye',
+                ENODO_EVENT_LOST_CLIENT_WITHOUT_GOODBYE)
             await EnodoEventManager.handle_event(event)
 
     @classmethod
     async def check_for_pending_series(cls, client):
-        from ..enodojobmanager import EnodoJobManager ## To stop circular import
-        pending_jobs = EnodoJobManager.get_active_jobs_by_worker(client.client_id)
+        from ..enodojobmanager import EnodoJobManager  # To stop circular import
+        pending_jobs = EnodoJobManager.get_active_jobs_by_worker(
+            client.client_id)
         if len(pending_jobs) > 0:
             for job in pending_jobs:
                 await EnodoJobManager.cancel_job(job)
                 series = await cls.series_manager.get_series(job.series_name)
-                await series.set_job_status(job.job_config.link_name, JOB_STATUS_OPEN)
-                logging.info(f'Setting for series job status pending to false...')
+                await series.set_job_status(
+                    job.job_config.link_name, JOB_STATUS_OPEN)
+                logging.info(
+                    f'Setting for series job status pending to false...')

--- a/lib/socket/clientmanager.py
+++ b/lib/socket/clientmanager.py
@@ -298,6 +298,6 @@ class ClientManager:
                 await EnodoJobManager.cancel_job(job)
                 series = await cls.series_manager.get_series(job.series_name)
                 await series.set_job_status(
-                    job.job_config.link_name, JOB_STATUS_OPEN)
+                    job.job_config.config_name, JOB_STATUS_OPEN)
                 logging.info(
                     f'Setting for series job status pending to false...')

--- a/lib/socket/clientmanager.py
+++ b/lib/socket/clientmanager.py
@@ -269,5 +269,5 @@ class ClientManager:
             for job in pending_jobs:
                 await EnodoJobManager.cancel_job(job)
                 series = await cls.series_manager.get_series(job.series_name)
-                await series.set_job_status(job.job_type, JOB_STATUS_OPEN)
+                await series.set_job_status(job.job_config.link_name, JOB_STATUS_OPEN)
                 logging.info(f'Setting for series job status pending to false...')

--- a/lib/socket/handler.py
+++ b/lib/socket/handler.py
@@ -1,21 +1,23 @@
-from enodo.jobs import JOB_TYPE_DETECT_ANOMALIES_FOR_SERIES
 from enodo.protocol.package import RESPONSE_OK, create_header
 
 
 from lib.series.seriesmanager import SeriesManager
-from lib.series import DETECT_ANOMALIES_STATUS_PENDING
 from lib.socket import ClientManager
 
-async def receive_new_series_points(writer, packet_type, packet_id, data, client_id):
+
+async def receive_new_series_points(writer, packet_type,
+                                    packet_id, data, client_id):
     for series_name in data.keys():
         series = await SeriesManager.get_series(series_name)
         if series is not None:
-            await SeriesManager.add_to_datapoint_counter(series_name, data.get(series_name))
+            await SeriesManager.add_to_datapoint_counter(
+                series_name, data.get(series_name))
     response = create_header(0, RESPONSE_OK, packet_id)
     writer.write(response)
 
 
-async def receive_worker_status_update(writer, packet_type, packet_id, data, client_id):
+async def receive_worker_status_update(writer, packet_type,
+                                       packet_id, data, client_id):
     busy = data
     worker = await ClientManager.get_worker_by_id(client_id)
     if worker is not None:
@@ -24,5 +26,6 @@ async def receive_worker_status_update(writer, packet_type, packet_id, data, cli
             worker.is_going_busy = False
 
 
-async def received_worker_refused(writer, packet_type, packet_id, data, client_id):
+async def received_worker_refused(writer, packet_type,
+                                  packet_id, data, client_id):
     print("Worker refused, is probably busy")

--- a/lib/socket/package.py
+++ b/lib/socket/package.py
@@ -54,9 +54,16 @@ async def read_packet(sock, header_data=None):
 
 
 def create_header(size, type, id):
-    return size.to_bytes(4, byteorder='big') + type.to_bytes(1, byteorder='big') + id.to_bytes(1, byteorder='big')
+    return size.to_bytes(4, byteorder='big') + \
+        type.to_bytes(1, byteorder='big') + \
+        id.to_bytes(1, byteorder='big')
 
 
 def read_header(binary_data):
-    return int.from_bytes(binary_data[:4], 'big'), int.from_bytes(binary_data[4:5], 'big'), int.from_bytes(
-        binary_data[5:6], 'big')
+    return int.from_bytes(
+        binary_data[: 4],
+        'big'), int.from_bytes(
+        binary_data[4: 5],
+        'big'), int.from_bytes(
+        binary_data[5: 6],
+        'big')

--- a/lib/socket/socketserver.py
+++ b/lib/socket/socketserver.py
@@ -1,16 +1,16 @@
 import asyncio
 import datetime
-import json
 import logging
 from packaging import version
 
 import qpack
 
 from lib.series.seriesmanager import SeriesManager
-from . import ClientManager, ListenerClient, WorkerClient
+from . import ClientManager
 from .package import *
 
 ENODO_HUB_WORKER_MIN_VERSION = "0.1.0-beta3.0"
+
 
 class SocketServer:
     def __init__(self, hostname, port, token, cbs=None):
@@ -25,15 +25,15 @@ class SocketServer:
     async def create(self, loop=None):
         loop = loop or asyncio.get_event_loop()
         self._server_running = True
-        coro = asyncio.start_server(self._handle_client_connection, self._hostname, self._port,
-                                    loop=loop)
+        coro = asyncio.start_server(
+            self._handle_client_connection, self._hostname, self._port,
+            loop=loop)
         self._server = loop.create_task(coro)
         self._server_coro = coro
 
     async def stop(self):
         self._server_running = False
         await self._server
-        # await self._server_coro
         self._server.cancel()
 
     async def _handle_client_connection(self, reader, writer):
@@ -51,83 +51,115 @@ class SocketServer:
                 connected = False
 
             if packet_type == HANDSHAKE:
-                client_data = data
-                client_id = client_data.get('client_id')
-                client_token = client_data.get('token')
-
-                if self._token is not None and (client_token is None or client_token != self._token):
-                    response = create_header(0, HANDSHAKE_FAIL, packet_id)
-                    writer.write(response)
-                    connected = False
-                else:
-                    if 'client_type' in client_data:
-                        if client_data.get('client_type') == 'listener':
-                            await ClientManager.listener_connected(writer.get_extra_info('peername'), writer,
-                                                    client_data)
-                            logging.info(f'New listener with id: {client_id}')
-                        elif client_data.get('client_type') == 'worker':
-                            supported_models = client_data.get('models')
-                            if supported_models is None or len(supported_models) < 1:
-                                response = create_header(0, HANDSHAKE_FAIL, packet_id)
-                                writer.write(response)
-                                connected = False
-                            else:
-                                if version.parse(client_data.get('version')) < version.parse(ENODO_HUB_WORKER_MIN_VERSION):
-                                    response = create_header(0, HANDSHAKE_FAIL, packet_id)
-                                    writer.write(response)
-                                    connected = False
-                                else:
-                                    await ClientManager.worker_connected(writer.get_extra_info('peername'), writer, client_data)
-                                    logging.info(f'New worker with id: {client_id}')
-
-                        response = create_header(0, HANDSHAKE_OK, packet_id)
-                        writer.write(response)
-
-                        if client_data.get('client_type') == 'listener':
-                            update = qpack.packb(SeriesManager.get_listener_series_info())
-                            series_update = create_header(len(update), UPDATE_SERIES, packet_id)
-                            writer.write(series_update + update)
-                    else:
-                        response = create_header(0, HANDSHAKE_FAIL, packet_id)
-                        writer.write(response)
-                saved_client_id = client_id
+                saved_client_id, connected = await self._handle_handshake(
+                    writer, packet_id, data)
             elif packet_type == HEARTBEAT:
-                client_id = data
-                l_client = await ClientManager.get_listener_by_id(client_id)
-                w_client = await ClientManager.get_worker_by_id(client_id)
-                if l_client is not None:
-                    logging.debug(f'Heartbeat from listener with id: {client_id}')
-                    l_client.last_seen = datetime.datetime.now()
-                    response = create_header(0, HEARTBEAT, packet_id)
-                    writer.write(response)
-                elif w_client is not None:
-                    logging.debug(f'Heartbeat from worker with id: {client_id}')
-                    w_client.last_seen = datetime.datetime.now()
-                    response = create_header(0, HEARTBEAT, packet_id)
-                    writer.write(response)
-                else:
-                    response = create_header(0, UNKNOWN_CLIENT, packet_id)
-                    writer.write(response)
+                await self._handle_heartbeat(writer, packet_id, data)
             elif packet_type == CLIENT_SHUTDOWN:
-                client_id = saved_client_id
-                l_client = await ClientManager.get_listener_by_id(client_id)
-                w_client = await ClientManager.get_worker_by_id(client_id)
-                if l_client is not None:
-                    logging.info(f'Listener {client_id} is going down, removing from client list...')
-                    await ClientManager.set_listener_offline(client_id)
-                elif w_client is not None:
-                    logging.info(f'Worker {client_id} is going down, removing from client list...')
-                    await ClientManager.set_worker_offline(client_id)
-
+                await self._handle_client_shutdown(saved_client_id)
                 connected = False
             else:
                 if packet_type in self._cbs:
-                    await self._cbs.get(packet_type)(writer, packet_type, packet_id, data, saved_client_id)
+                    await self._cbs.get(packet_type)(writer, packet_type,
+                                                     packet_id, data,
+                                                     saved_client_id)
                 else:
-                    logging.debug(f'Package type {packet_type} not implemented')
+                    logging.debug(
+                        f'Package type {packet_type} not implemented')
 
             await writer.drain()
 
         logging.info(f'Closing socket with client {saved_client_id}')
         await ClientManager.assert_if_client_is_offline(saved_client_id)
         writer.close()
+
+    async def _handle_client_shutdown(self, saved_client_id):
+        client_id = saved_client_id
+        l_client = await ClientManager.get_listener_by_id(client_id)
+        w_client = await ClientManager.get_worker_by_id(client_id)
+        if l_client is not None:
+            logging.info(
+                f'Listener {client_id} is going down, \
+                    removing from client list...')
+            await ClientManager.set_listener_offline(client_id)
+        elif w_client is not None:
+            logging.info(
+                f'Worker {client_id} is going down, \
+                    removing from client list...')
+            await ClientManager.set_worker_offline(client_id)
+
+    async def _handle_heartbeat(self, writer, packet_id, data):
+        client_id = data
+        l_client = await ClientManager.get_listener_by_id(client_id)
+        w_client = await ClientManager.get_worker_by_id(client_id)
+        if l_client is not None:
+            logging.debug(
+                f'Heartbeat from listener with id: {client_id}')
+            l_client.last_seen = datetime.datetime.now()
+            response = create_header(0, HEARTBEAT, packet_id)
+            writer.write(response)
+        elif w_client is not None:
+            logging.debug(
+                f'Heartbeat from worker with id: {client_id}')
+            w_client.last_seen = datetime.datetime.now()
+            response = create_header(0, HEARTBEAT, packet_id)
+            writer.write(response)
+        else:
+            response = create_header(
+                0, UNKNOWN_CLIENT, packet_id)
+            writer.write(response)
+
+    async def _handle_handshake(self, writer, packet_id, data):
+        client_data = data
+        client_id = client_data.get('client_id')
+        client_token = client_data.get('token')
+
+        if self._token is not None and (
+                client_token
+                is None or client_token
+                != self._token):
+            response = create_header(0, HANDSHAKE_FAIL, packet_id)
+            writer.write(response)
+            return client_id, False
+
+        if 'client_type' not in client_data:
+            response = create_header(0, HANDSHAKE_FAIL, packet_id)
+            writer.write(response)
+            return client_id, False
+
+        if client_data.get('client_type') == 'listener':
+            await ClientManager.listener_connected(
+                writer.get_extra_info('peername'),
+                writer,
+                client_data)
+            logging.info(
+                f'New listener with id: {client_id}')
+        elif client_data.get('client_type') == 'worker':
+            supported_models = client_data.get('models')
+            if supported_models is None or len(supported_models) < 1:
+                response = create_header(0, HANDSHAKE_FAIL, packet_id)
+                writer.write(response)
+                return client_id, False
+
+            if version.parse(
+                    client_data.get('version')) < version.parse(
+                    ENODO_HUB_WORKER_MIN_VERSION):
+                response = create_header(0, HANDSHAKE_FAIL, packet_id)
+                writer.write(response)
+                return client_id, False
+
+            await ClientManager.worker_connected(
+                writer.get_extra_info('peername'), writer, client_data)
+            logging.info(f'New worker with id: {client_id}')
+            response = create_header(0, HANDSHAKE_OK, packet_id)
+            writer.write(response)
+            return client_id, True
+
+        if client_data.get('client_type') == 'listener':
+            update = qpack.packb(
+                SeriesManager.get_listener_series_info())
+            header = create_header(len(update), UPDATE_SERIES, packet_id)
+            writer.write(header + update)
+            return client_id, True
+
+        

--- a/lib/socket/socketserver.py
+++ b/lib/socket/socketserver.py
@@ -79,13 +79,13 @@ class SocketServer:
         w_client = await ClientManager.get_worker_by_id(client_id)
         if l_client is not None:
             logging.info(
-                f'Listener {client_id} is going down, \
-                    removing from client list...')
+                f'Listener {client_id} is going down'
+                'removing from client list...')
             await ClientManager.set_listener_offline(client_id)
         elif w_client is not None:
             logging.info(
-                f'Worker {client_id} is going down, \
-                    removing from client list...')
+                f'Worker {client_id} is going down'
+                'removing from client list...')
             await ClientManager.set_worker_offline(client_id)
 
     async def _handle_heartbeat(self, writer, packet_id, data):
@@ -158,8 +158,8 @@ class SocketServer:
         if client_data.get('client_type') == 'listener':
             update = qpack.packb(
                 SeriesManager.get_listener_series_info())
-            header = create_header(len(update), UPDATE_SERIES, packet_id)
+            header = create_header(
+                len(update),
+                UPDATE_SERIES, packet_id)
             writer.write(header + update)
             return client_id, True
-
-        

--- a/lib/socketio/socketiohandlers.py
+++ b/lib/socketio/socketiohandlers.py
@@ -62,8 +62,32 @@ class SocketIoHandler:
     @socketio_auth_required
     async def get_series_details(cls, sid, data, event):
         series_name = data.get('series_name')
-        resp = await BaseHandler.resp_get_monitored_series_details(
-            series_name, include_points=True)
+        resp = await BaseHandler.resp_get_single_monitored_series(
+            series_name)
+        return safe_json_dumps(resp)
+
+    @classmethod
+    @socketio_auth_required
+    async def get_series_forecasts(cls, sid, data, event):
+        series_name = data.get('series_name')
+        resp = await BaseHandler.resp_get_series_forecasts(
+            series_name)
+        return safe_json_dumps(resp)
+
+    @classmethod
+    @socketio_auth_required
+    async def get_series_anomalies(cls, sid, data, event):
+        series_name = data.get('series_name')
+        resp = await BaseHandler.resp_get_series_anomalies(
+            series_name)
+        return safe_json_dumps(resp)
+
+    @classmethod
+    @socketio_auth_required
+    async def get_series_static_rules_hits(cls, sid, data, event):
+        series_name = data.get('series_name')
+        resp = await BaseHandler.resp_get_series_static_rules_hits(
+            series_name)
         return safe_json_dumps(resp)
 
     @classmethod

--- a/lib/socketio/socketiohandlers.py
+++ b/lib/socketio/socketiohandlers.py
@@ -1,5 +1,4 @@
 import functools
-from lib.series.seriesmanager import SeriesManager
 
 from lib.socketio.subscriptionmanager import SubscriptionManager
 from lib.util import safe_json_dumps
@@ -63,7 +62,8 @@ class SocketIoHandler:
     @socketio_auth_required
     async def get_series_details(cls, sid, data, event):
         series_name = data.get('series_name')
-        resp = await BaseHandler.resp_get_monitored_series_details(series_name, include_points=True)
+        resp = await BaseHandler.resp_get_monitored_series_details(
+            series_name, include_points=True)
         return safe_json_dumps(resp)
 
     @classmethod
@@ -87,7 +87,8 @@ class SocketIoHandler:
         else:
             series_name = data.get('name')
             if series_name is not None:
-                resp = {'status': await BaseHandler.resp_remove_series(series_name)}
+                resp = {'status':
+                        await BaseHandler.resp_remove_series(series_name)}
             else:
                 resp = {'error': 'Missing required field(s)'}
         return safe_json_dumps(resp)
@@ -96,14 +97,14 @@ class SocketIoHandler:
     @socketio_auth_required
     async def update_series(cls, sid, data, event):
         if not isinstance(data, dict):
-            resp = {'error': 'Incorrect data'}
+            return safe_json_dumps({'error': 'Incorrect data'})
+        series_name = data.get('name')
+        series_data = data.get('data')
+        if series_name is not None:
+            resp, status = await BaseHandler.resp_update_series(
+                series_name, series_data)
         else:
-            series_name = data.get('name')
-            series_data = data.get('data')
-            if series_name is not None:
-                resp, status = await BaseHandler.resp_update_series(series_name, series_data)
-            else:
-                resp = {'error': 'Missing required field(s)'}
+            resp = {'error': 'Missing required field(s)'}
         return safe_json_dumps(resp)
 
     @classmethod
@@ -129,7 +130,8 @@ class SocketIoHandler:
     @classmethod
     @socketio_auth_required
     async def resolve_failed_job(cls, sid, data, event=None):
-        return await BaseHandler.resp_resolve_failed_job(data.get('series_name'))
+        return await BaseHandler.resp_resolve_failed_job(
+            data.get('series_name'))
 
     @classmethod
     @socketio_auth_required
@@ -141,14 +143,16 @@ class SocketIoHandler:
     async def add_event_output(cls, sid, data, event=None):
         output_type = data.get('output_type')
         output_data = data.get('data')
-        return await BaseHandler.resp_add_event_output(output_type, output_data)
+        return await BaseHandler.resp_add_event_output(
+            output_type, output_data)
 
     @classmethod
     @socketio_auth_required
     async def update_event_output(cls, sid, data, event=None):
         output_id = data.get('id')
         output_data = data.get('data')
-        return await BaseHandler.resp_update_event_output(output_id, output_data)
+        return await BaseHandler.resp_update_event_output(
+            output_id, output_data)
 
     @classmethod
     @socketio_auth_required
@@ -284,7 +288,8 @@ class SocketIoHandler:
             }, room='job_updates')
 
     @classmethod
-    async def internal_updates_series_subscribers(cls, change_type, series, name=None):
+    async def internal_updates_series_subscribers(cls, change_type,
+                                                  series, name=None):
         if cls._sio is not None:
             await cls._sio.emit('update', {
                 'resource': 'series',
@@ -292,7 +297,8 @@ class SocketIoHandler:
                 'resourceData': series
             }, room='series_updates')
 
-        filtered_subs = await SubscriptionManager.get_subscriptions_for_series_name(name)
+        filtered_subs = \
+            await SubscriptionManager.get_subscriptions_for_series_name(name)
         for sub in filtered_subs:
             await cls._sio.emit('update', {
                 'resource': 'series',
@@ -301,7 +307,8 @@ class SocketIoHandler:
             }, room=sub.get('sid'))
 
     @classmethod
-    async def internal_updates_enodo_models_subscribers(cls, change_type, model_data):
+    async def internal_updates_enodo_models_subscribers(cls, change_type,
+                                                        model_data):
         if cls._sio is not None:
             await cls._sio.emit('update', {
                 'resource': 'enodo_model',

--- a/lib/socketio/socketiorouter.py
+++ b/lib/socketio/socketiorouter.py
@@ -26,6 +26,15 @@ class SocketIoRouter:
             event='/api/series/details',
             handler=SocketIoHandler.get_series_details)
         self._sio_on(
+            event='/api/series/forecasts',
+            handler=SocketIoHandler.get_series_forecasts)
+        self._sio_on(
+            event='/api/series/details',
+            handler=SocketIoHandler.get_series_anomalies)
+        self._sio_on(
+            event='/api/series/details',
+            handler=SocketIoHandler.get_series_static_rules_hits)
+        self._sio_on(
             event='/api/series/delete',
             handler=SocketIoHandler.remove_series)
         self._sio_on(

--- a/lib/webserver/basehandler.py
+++ b/lib/webserver/basehandler.py
@@ -276,26 +276,6 @@ class BaseHandler:
         return {'data': data}
 
     @classmethod
-    async def resp_add_model(cls, data):
-        """Add model
-
-        Args:
-            data (dict): config of model
-
-        Returns:
-            dict: dict with data
-            dict: dict with error message
-        """
-        try:
-            await EnodoModelManager.add_model(data['model_name'],
-                                              data['model_arguments'])
-            data = [EnodoModel.to_dict(m)
-                    for m in EnodoModelManager.models]
-            return {'data': data}, 201
-        except Exception:
-            return {'error': 'Incorrect model data'}, 400
-
-    @classmethod
     async def resp_get_enodo_hub_status(cls):
         return {'data': {'version': VERSION}}
 

--- a/lib/webserver/basehandler.py
+++ b/lib/webserver/basehandler.py
@@ -8,7 +8,8 @@ from lib.analyser.model import EnodoModelManager
 from lib.events import EnodoEventManager
 from lib.series.seriesmanager import SeriesManager
 from lib.serverstate import ServerState
-from lib.siridb.siridb import query_series_data
+from lib.siridb.siridb import query_series_anomalies, query_series_forecasts, \
+    query_series_static_rules_hits
 from lib.util import regex_valid
 from lib.enodojobmanager import EnodoJobManager, EnodoJob
 from lib.socketio import SUBSCRIPTION_CHANGE_TYPE_UPDATE
@@ -28,37 +29,74 @@ class BaseHandler:
         Returns:
             dict: dict with data
         """
-        if regex_filter is not None:
-            if not regex_valid(regex_filter):
-                return {'data': []}
+        if regex_filter is not None and not regex_valid(regex_filter):
+            return {'data': []}
         return {'data': list(
             await SeriesManager.get_series_to_dict(regex_filter))}
 
     @classmethod
-    async def resp_get_monitored_series_details(cls, series_name,
-                                                include_points=False):
+    async def resp_get_single_monitored_series(cls, series_name):
         """Get monitored series details
 
         Args:
             series_name (string): name of series
-            include_points (bool, optional): if points need to be returned.
-                Defaults to False.
 
         Returns:
             dict: dict with data
         """
         series = await SeriesManager.get_series(series_name)
-
         if series is None:
             return web.json_response(data={'data': ''}, status=404)
-
         series_data = series.to_dict()
-        if include_points:
-            series_points = await query_series_data(
-                ServerState.get_siridb_data_conn(), series.name, "*")
-            series_data['points'] = series_points.get(series.name)
-
         return {'data': series_data}
+
+    @classmethod
+    async def resp_get_series_forecasts(cls, series_name):
+        """Get series forecast results
+
+        Args:
+            series_name (string): name of series
+
+        Returns:
+            dict: dict with data
+        """
+        series = await SeriesManager.get_series(series_name)
+        if series is None:
+            return web.json_response(data={'data': ''}, status=404)
+        return {'data': await query_series_forecasts(
+            ServerState.get_siridb_data_conn(), series_name)}
+
+    @classmethod
+    async def resp_get_series_anomalies(cls, series_name):
+        """Get series anomalies results
+
+        Args:
+            series_name (string): name of series
+
+        Returns:
+            dict: dict with data
+        """
+        series = await SeriesManager.get_series(series_name)
+        if series is None:
+            return web.json_response(data={'data': ''}, status=404)
+        return {'data': await query_series_anomalies(
+            ServerState.get_siridb_data_conn(), series_name)}
+
+    @classmethod
+    async def resp_get_series_static_rules_hits(cls, series_name):
+        """Get series static rules hits
+
+        Args:
+            series_name (string): name of series
+
+        Returns:
+            dict: dict with data
+        """
+        series = await SeriesManager.get_series(series_name)
+        if series is None:
+            return web.json_response(data={'data': ''}, status=404)
+        return {'data': await query_series_static_rules_hits(
+            ServerState.get_siridb_data_conn(), series_name)}
 
     @classmethod
     async def resp_get_event_outputs(cls):

--- a/lib/webserver/basehandler.py
+++ b/lib/webserver/basehandler.py
@@ -69,7 +69,7 @@ class BaseHandler:
         try:
             series_config = SeriesConfigModel.from_dict(data.get('config'))
         except Exception as e:
-            return {'error': f'Invalid series config'}, 400
+            return {'error': f'Invalid series config', 'message': str(e)}, 400
         for job_config in list(series_config.job_config.values()):
             model_parameters = job_config.model_params
 

--- a/lib/webserver/routes.py
+++ b/lib/webserver/routes.py
@@ -15,8 +15,22 @@ def setup_routes(app, cors):
     app.router.add_post(
         "/api/series", ApiHandlers.add_series)
     app.router.add_get(
-        "/api/series/{series_name}", ApiHandlers.get_monitored_series_details,
+        "/api/series/{series_name}", ApiHandlers.get_single_monitored_series,
         allow_head=False)
+
+    app.router.add_get(
+        "/api/series/{series_name}/forecasts",
+        ApiHandlers.get_series_forecast,
+        allow_head=False)
+    app.router.add_get(
+        "/api/series/{series_name}/anomlies",
+        ApiHandlers.get_series_anomalies,
+        allow_head=False)
+    app.router.add_get(
+        "/api/series/{series_name}/static_rules",
+        ApiHandlers.get_series_static_rules_hits,
+        allow_head=False)
+
     app.router.add_delete(
         "/api/series/{series_name}", ApiHandlers.remove_series)
     app.router.add_get(

--- a/lib/webserver/routes.py
+++ b/lib/webserver/routes.py
@@ -2,6 +2,12 @@ from lib.api.apihandlers import ApiHandlers
 
 
 def setup_routes(app, cors):
+    """Add REST API routes
+
+    Args:
+        app (instance): AIOHTTP app instance
+        cors (CorsConfig): cors
+    """
     # Add rest api routes
     app.router.add_get(
         "/api/series", ApiHandlers.get_monitored_series,

--- a/lib/webserver/routes.py
+++ b/lib/webserver/routes.py
@@ -23,7 +23,7 @@ def setup_routes(app, cors):
         ApiHandlers.get_series_forecast,
         allow_head=False)
     app.router.add_get(
-        "/api/series/{series_name}/anomlies",
+        "/api/series/{series_name}/anomalies",
         ApiHandlers.get_series_anomalies,
         allow_head=False)
     app.router.add_get(

--- a/lib/webserver/routes.py
+++ b/lib/webserver/routes.py
@@ -1,0 +1,61 @@
+from lib.api.apihandlers import ApiHandlers
+
+
+def setup_routes(app, cors):
+    # Add rest api routes
+    app.router.add_get(
+        "/api/series", ApiHandlers.get_monitored_series,
+        allow_head=False)
+    app.router.add_post(
+        "/api/series", ApiHandlers.add_series)
+    app.router.add_get(
+        "/api/series/{series_name}", ApiHandlers.get_monitored_series_details,
+        allow_head=False)
+    app.router.add_delete(
+        "/api/series/{series_name}", ApiHandlers.remove_series)
+    app.router.add_get(
+        "/api/enodo/model", ApiHandlers.get_possible_analyser_models,
+        allow_head=False)
+    app.router.add_post(
+        "/api/enodo/model", ApiHandlers.add_analyser_models)
+    app.router.add_get(
+        "/api/enodo/event/output", ApiHandlers.get_enodo_event_outputs)
+    app.router.add_delete(
+        "/api/enodo/event/output/{output_id}",
+        ApiHandlers.remove_enodo_event_output)
+    app.router.add_post(
+        "/api/enodo/event/output", ApiHandlers.add_enodo_event_output)
+    app.router.add_get(
+        "/api/enodo/stats", ApiHandlers.get_enodo_stats)
+    app.router.add_get(
+        "/api/enodo/label", ApiHandlers.get_enodo_labels,
+        allow_head=False)
+    app.router.add_post(
+        "/api/enodo/label", ApiHandlers.add_enodo_label)
+    app.router.add_delete(
+        "/api/enodo/label", ApiHandlers.remove_enodo_label)
+
+    # Add internal api routes
+    app.router.add_get(
+        "/api/settings", ApiHandlers.get_settings,
+        allow_head=False)
+    app.router.add_post(
+        "/api/settings", ApiHandlers.update_settings)
+    app.router.add_get(
+        "/api/enodo/status", ApiHandlers.get_siridb_enodo_status,
+        allow_head=False)
+    app.router.add_get(
+        "/api/enodo/log", ApiHandlers.get_event_log,
+        allow_head=False)
+    app.router.add_get(
+        "/api/enodo/clients", ApiHandlers.get_connected_clients,
+        allow_head=False)
+
+    # Add non api routes
+    app.router.add_get(
+        "/status/ready", ApiHandlers.get_enodo_readiness,
+        allow_head=False)
+
+    # Configure CORS on all routes.
+    for route in list(app.router.routes()):
+        cors.add(route)

--- a/lib/webserver/routes.py
+++ b/lib/webserver/routes.py
@@ -36,8 +36,6 @@ def setup_routes(app, cors):
     app.router.add_get(
         "/api/enodo/model", ApiHandlers.get_possible_analyser_models,
         allow_head=False)
-    app.router.add_post(
-        "/api/enodo/model", ApiHandlers.add_analyser_models)
     app.router.add_get(
         "/api/enodo/event/output", ApiHandlers.get_enodo_event_outputs)
     app.router.add_delete(

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ aiohttp_cors==0.7.0
 jinja2==2.11.3
 marshmallow==3.10.0
 psutil==5.8.0
-python-enodo==0.1.16
+python-enodo==0.2.1
 python-socketio==5.0.4
 qpack==0.0.17
 siridb-connector==2.0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ python-enodo==0.1.16
 python-socketio==5.0.4
 qpack==0.0.17
 siridb-connector==2.0.8
+packaging==21.3
+MarkupSafe==2.0.1

--- a/server.py
+++ b/server.py
@@ -180,7 +180,7 @@ class Server:
                     await series.is_job_due(job_config_name):
                 await EnodoJobManager.create_job(job_config_name, series_name)
                 continue
-            elif job_config_name not in job_schedules:
+            if job_config_name not in job_schedules:
                 # Job has not been schedules yet, let's add it
                 await series.schedule_job(job_config_name, initial=True)
 

--- a/server.py
+++ b/server.py
@@ -1,6 +1,7 @@
 import datetime
 
 import asyncio
+from email.mime import base
 import logging
 
 import aiohttp_cors
@@ -171,6 +172,7 @@ class Server:
         # Only continue if base analysis has finished
         if series.base_analysis_status() != JOB_STATUS_DONE:
             return
+
         # loop through scheduled jobs:
         job_schedules = series.state.get_all_job_schedules()
         for job_link_name in series.series_config.job_config:
@@ -178,7 +180,7 @@ class Server:
                     await series.is_job_due(job_link_name):
                 await EnodoJobManager.create_job(job_link_name, series_name)
                 continue
-            else:
+            elif job_link_name not in job_schedules:
                 # Job has not been schedules yet, let's add it
                 await series.schedule_job(job_link_name, initial=True)
 

--- a/server.py
+++ b/server.py
@@ -168,21 +168,21 @@ class Server:
         if series.base_analysis_status() == JOB_STATUS_NONE:
             base_analysis_job = series.base_analysis_job
             await EnodoJobManager.create_job(
-                base_analysis_job.link_name, series_name)
+                base_analysis_job.config_name, series_name)
         # Only continue if base analysis has finished
         if series.base_analysis_status() != JOB_STATUS_DONE:
             return
 
         # loop through scheduled jobs:
         job_schedules = series.state.get_all_job_schedules()
-        for job_link_name in series.series_config.job_config:
-            if job_link_name in job_schedules and \
-                    await series.is_job_due(job_link_name):
-                await EnodoJobManager.create_job(job_link_name, series_name)
+        for job_config_name in series.series_config.job_config:
+            if job_config_name in job_schedules and \
+                    await series.is_job_due(job_config_name):
+                await EnodoJobManager.create_job(job_config_name, series_name)
                 continue
-            elif job_link_name not in job_schedules:
+            elif job_config_name not in job_schedules:
                 # Job has not been schedules yet, let's add it
-                await series.schedule_job(job_link_name, initial=True)
+                await series.schedule_job(job_config_name, initial=True)
 
     async def watch_series(self):
         """Background task to check each series if

--- a/server.py
+++ b/server.py
@@ -13,19 +13,20 @@ from lib.api.apihandlers import ApiHandlers, auth
 from lib.config import Config
 from lib.events.enodoeventmanager import EnodoEventManager
 from lib.enodojobmanager import EnodoJobManager
-from enodo.jobs import JOB_STATUS_OPEN, JOB_STATUS_PENDING, JOB_TYPE_BASE_SERIES_ANALYSIS, JOB_TYPE_FORECAST_SERIES, JOB_TYPE_DETECT_ANOMALIES_FOR_SERIES, JOB_TYPE_STATIC_RULES, JOB_STATUS_NONE, JOB_STATUS_DONE
+from enodo.jobs import JOB_STATUS_NONE, JOB_STATUS_DONE
 from lib.logging import prepare_logger
 from lib.series.seriesmanager import SeriesManager
 from lib.serverstate import ServerState
 from lib.socket import ClientManager
-from lib.socket.handler import receive_new_series_points, receive_worker_status_update, \
-    received_worker_refused
-from lib.socket.package import LISTENER_NEW_SERIES_POINTS, WORKER_UPDATE_BUSY, WORKER_JOB_RESULT, WORKER_REFUSED, \
-    WORKER_JOB_CANCELLED
+from lib.socket.handler import receive_new_series_points, \
+    receive_worker_status_update, received_worker_refused
+from lib.socket.package import LISTENER_NEW_SERIES_POINTS, WORKER_UPDATE_BUSY,\
+    WORKER_JOB_RESULT, WORKER_REFUSED, WORKER_JOB_CANCELLED
 from lib.socket.socketserver import SocketServer
 from lib.socketio.socketiohandlers import SocketIoHandler
 from lib.socketio.socketiorouter import SocketIoRouter
 from lib.util import print_custom_aiohttp_startup_message
+from lib.webserver.routes import setup_routes
 
 
 class Server:
@@ -52,18 +53,21 @@ class Server:
         # Setup server state object
         await ServerState.async_setup(sio=self.sio)
 
-        # Setup internal security token for authenticating backend socket connections
+        # Setup internal security token for authenticating
+        # backend socket connections
         logging.info('Setting up internal communications token...')
         Config.setup_internal_security_token()
 
         # Setup backend socket connection
-        self.backend_socket = SocketServer(Config.socket_server_host, Config.socket_server_port,
-                                           Config.internal_security_token,
-                                           {LISTENER_NEW_SERIES_POINTS: receive_new_series_points,
-                                            WORKER_JOB_RESULT: EnodoJobManager.receive_job_result,
-                                            WORKER_UPDATE_BUSY: receive_worker_status_update,
-                                            WORKER_REFUSED: received_worker_refused,
-                                            WORKER_JOB_CANCELLED: EnodoJobManager.receive_worker_cancelled_job})
+        self.backend_socket = SocketServer(
+            Config.socket_server_host, Config.socket_server_port,
+            Config.internal_security_token,
+            {LISTENER_NEW_SERIES_POINTS: receive_new_series_points,
+             WORKER_JOB_RESULT: EnodoJobManager.receive_job_result,
+             WORKER_UPDATE_BUSY: receive_worker_status_update,
+             WORKER_REFUSED: received_worker_refused,
+             WORKER_JOB_CANCELLED: EnodoJobManager.
+             receive_worker_cancelled_job})
 
         # Setup REST API handlers
         await ApiHandlers.prepare()
@@ -73,28 +77,36 @@ class Server:
             await SocketIoHandler.prepare(self.sio)
             SocketIoRouter(self.sio)
 
-        # Setup internal managers for handling and managing series, clients, jobs, events and models
-        await SeriesManager.prepare(SocketIoHandler.internal_updates_series_subscribers)
+        # Setup internal managers for handling and managing series,
+        # clients, jobs, events and models
+        await SeriesManager.prepare(
+            SocketIoHandler.internal_updates_series_subscribers)
         await SeriesManager.read_from_disk()
         await ClientManager.setup(SeriesManager)
-        await EnodoJobManager.async_setup(SocketIoHandler.internal_updates_queue_subscribers)
+        await EnodoJobManager.async_setup(
+            SocketIoHandler.internal_updates_queue_subscribers)
         await EnodoJobManager.load_from_disk()
         await EnodoEventManager.async_setup()
         await EnodoEventManager.load_from_disk()
-        await EnodoModelManager.async_setup(SocketIoHandler.internal_updates_enodo_models_subscribers)
+        await EnodoModelManager.async_setup(
+            SocketIoHandler.internal_updates_enodo_models_subscribers)
         await EnodoModelManager.load_from_disk()
 
         # Setup background tasks
-        self._watch_series_task = self.loop.create_task(self.watch_series())
-        self._save_to_disk_task = self.loop.create_task(self.save_to_disk())
+        self._watch_series_task = self.loop.create_task(
+            self.watch_series())
+        self._save_to_disk_task = self.loop.create_task(
+            self.save_to_disk())
         self._check_jobs_task = self.loop.create_task(
             EnodoJobManager.check_for_jobs())
         self._connection_management_task = self.loop.create_task(
             self._manage_connections())
-        self._watch_tasks_task = self.loop.create_task(self.watch_tasks())
+        self._watch_tasks_task = self.loop.create_task(
+            self.watch_tasks())
 
         # Open backend socket connection
         await self.backend_socket.create()
+        ServerState.readiness = True
 
     async def clean_up(self):
         """
@@ -111,7 +123,8 @@ class Server:
     async def _manage_connections(self):
         while ServerState.running:
             await asyncio.sleep(Config.save_to_disk_interval)
-            ServerState.tasks_last_runs['manage_connections'] = datetime.datetime.now()
+            ServerState.tasks_last_runs['manage_connections'] = \
+                datetime.datetime.now()
             logging.debug('Cleaning-up clients')
             await ClientManager.check_clients_alive(Config.client_max_timeout)
             logging.debug('Refreshing SiriDB connection status')
@@ -123,56 +136,71 @@ class Server:
             logging.debug('Watching background tasks')
             try:
                 for task in ServerState.tasks_last_runs:
-                    if ServerState.tasks_last_runs[task] is not None and \
-                        (datetime.datetime.now() - ServerState.tasks_last_runs[task]).total_seconds() > 60:
-                        logging.error(f"Background task \"{task}\" is unresponsive!")
+                    last_run = ServerState.tasks_last_runs[task]
+                    now = datetime.datetime.now()
+                    if last_run is not None and \
+                            (now - last_run).total_seconds() > 60:
+                        logging.error(
+                            f"Background task \"{task}\" is unresponsive!")
             except Exception as e:
                 logging.error('Watching background tasks failed')
 
+    async def _check_for_jobs(self, series, series_name):
+        # Check if series does not have any failed jobs
+        if len(EnodoJobManager.get_failed_jobs_for_series(series_name)):
+            return
+
+        # Check if base analysis has already run
+        if series.base_analysis_status() == JOB_STATUS_NONE:
+            base_analysis_job = series.base_analysis_job
+            await EnodoJobManager.create_job(
+                base_analysis_job.link_name, series_name)
+        # Only continue if base analysis has finished
+        if series.base_analysis_status() != JOB_STATUS_DONE:
+            return
+        # loop through scheduled jobs:
+        job_schedules = series.state.get_all_job_schedules()
+        for job_link_name in series.series_config.job_config:
+            if job_link_name in job_schedules and \
+                    await series.is_job_due(job_link_name):
+                await EnodoJobManager.create_job(job_link_name, series_name)
+                continue
+            else:
+                # Job has not been schedules yet, let's add it
+                await series.schedule_job(job_link_name, initial=True)
+
     async def watch_series(self):
-        try:
-            while ServerState.running:
-                ServerState.tasks_last_runs['watch_series'] = datetime.datetime.now()
-                series_names = SeriesManager.get_all_series()
-                for series_name in series_names:
-                    series = await SeriesManager.get_series(series_name)       
-                    # Check if series is valid and not ignored
-                    if series is not None \
-                            and not series.is_ignored():
-                        # Check if requirement of min amount of datapoints is met
-                        if series.get_datapoints_count() is not None and series.get_datapoints_count() >= Config.min_data_points or (
-                            series.series_config.min_data_points is not None and series.get_datapoints_count() is not None and series.get_datapoints_count() >= series.series_config.min_data_points):
-                            try:
-                                # Check if series does not have any failed jobs
-                                if not len(EnodoJobManager.get_failed_jobs_for_series(series_name)):
-                                    if series.base_analysis_status() == JOB_STATUS_NONE:
-                                        base_analysis_job = series.base_analysis_job
-                                        await EnodoJobManager.create_job(base_analysis_job.link_name, series_name)
+        while ServerState.running:
+            ServerState.tasks_last_runs['watch_series'] = \
+                datetime.datetime.now()
 
-                                    elif series.base_analysis_status() == JOB_STATUS_DONE:
-                                        
-                                        # loop through scheduled jobs:
-                                        job_schedules = series.state.get_all_job_schedules()
-                                        for job_link_name in series.series_config.job_config:
-                                            if job_link_name in job_schedules:
-                                                if series.state.get_job_status(job_link_name) in [JOB_STATUS_OPEN, JOB_STATUS_PENDING]:
-                                                    continue
-                                                    
-                                                if await series.is_job_due(job_link_name):
-                                                    await EnodoJobManager.create_job(job_link_name, series_name)
-                                                    continue
-                                            else:
-                                                # Job has not been schedules yet, lets add it
-                                                await series.schedule_job(job_link_name, initial=True)
-                            except Exception as e:
-                                logging.error(f"Something went wrong when trying to create new job")
-                                import traceback
-                                traceback.print_exc()
-                                logging.debug(f"Corresponding error: {e}")
+            series_names = SeriesManager.get_all_series()
+            for series_name in series_names:
+                series = await SeriesManager.get_series(series_name)
+                # Check if series is valid and not ignored
+                if series is None or series.is_ignored():
+                    continue
 
-                await asyncio.sleep(Config.watcher_interval)
-        except Exception as e:
-            print(e)
+                # Check if requirement of min amount of datapoints is met
+                if series.get_datapoints_count() is None:
+                    continue
+                if series.series_config.min_data_points is not None and \
+                        series.get_datapoints_count() is not None:
+                    if series.get_datapoints_count() < \
+                            series.series_config.min_data_points:
+                        continue
+                elif series.get_datapoints_count() < Config.min_data_points:
+                    continue
+
+                try:
+                    await self._check_for_jobs(series, series_name)
+                except Exception as e:
+                    logging.error(
+                        f"Something went wrong when trying to create new job")
+                    logging.debug(
+                        f"Corresponding error: {e}")
+
+            await asyncio.sleep(Config.watcher_interval)
 
     @staticmethod
     async def _save_to_disk():
@@ -187,15 +215,18 @@ class Server:
     async def save_to_disk(self):
         while ServerState.running:
             await asyncio.sleep(Config.save_to_disk_interval)
-            ServerState.tasks_last_runs['save_to_disk'] = datetime.datetime.now()
+            ServerState.tasks_last_runs['save_to_disk'] = \
+                datetime.datetime.now()
             logging.debug('Saving seriesmanager state to disk')
             await self._save_to_disk()
 
     async def stop_server(self):
         logging.info('Stopping Hub...')
+        ServerState.readiness = False
         if self.sio is not None:
             clients = []
-            if '/' in self.sio.manager.rooms and None in self.sio.manager.rooms['/']:
+            if '/' in self.sio.manager.rooms and \
+                    None in self.sio.manager.rooms['/']:
                 clients = self.sio.manager.rooms['/'][None]
             for sid in clients:
                 if sid is not None:
@@ -222,7 +253,6 @@ class Server:
         logging.info('...Stopping all running tasks')
         logging.info('...Going down in 1')
         await asyncio.sleep(1)
-        # asyncio.gather(*asyncio.Task.all_tasks()).cancel()
         for task in asyncio.Task.all_tasks():
             try:
                 task.cancel()
@@ -241,7 +271,6 @@ class Server:
         Config.read_config(self._config_path)
         logging.info('Starting...')
         logging.info('Loaded Config...')
-
         logging.info('Running API\'s in secure mode...')
         self.app = web.Application(middlewares=[auth])
 
@@ -254,49 +283,7 @@ class Server:
                     allow_headers="*",
                 )
             })
-
-            # Add rest api routes
-            self.app.router.add_get(
-                "/api/series", ApiHandlers.get_monitored_series, allow_head=False)
-            self.app.router.add_post("/api/series", ApiHandlers.add_series) 
-            self.app.router.add_get("/api/series/{series_name}", ApiHandlers.get_monitored_series_details,
-                                    allow_head=False)
-            self.app.router.add_delete(
-                "/api/series/{series_name}", ApiHandlers.remove_series)
-            self.app.router.add_get(
-                "/api/enodo/model", ApiHandlers.get_possible_analyser_models, allow_head=False)
-            self.app.router.add_post(
-                "/api/enodo/model", ApiHandlers.add_analyser_models)
-            self.app.router.add_get(
-                "/api/enodo/event/output", ApiHandlers.get_enodo_event_outputs)
-            self.app.router.add_delete(
-                "/api/enodo/event/output/{output_id}", ApiHandlers.remove_enodo_event_output)
-            self.app.router.add_post(
-                "/api/enodo/event/output", ApiHandlers.add_enodo_event_output)
-            self.app.router.add_get(
-                "/api/enodo/stats", ApiHandlers.get_enodo_stats)
-            self.app.router.add_get(
-                "/api/enodo/label", ApiHandlers.get_enodo_labels, allow_head=False)
-            self.app.router.add_post(
-                "/api/enodo/label", ApiHandlers.add_enodo_label)
-            self.app.router.add_delete(
-                "/api/enodo/label", ApiHandlers.remove_enodo_label)
-
-            # Add internal api routes
-            self.app.router.add_get(
-                "/api/settings", ApiHandlers.get_settings, allow_head=False)
-            self.app.router.add_post(
-                "/api/settings", ApiHandlers.update_settings)
-            self.app.router.add_get(
-                "/api/enodo/status", ApiHandlers.get_siridb_enodo_status, allow_head=False)
-            self.app.router.add_get(
-                "/api/enodo/log", ApiHandlers.get_event_log, allow_head=False)
-            self.app.router.add_get(
-                "/api/enodo/clients", ApiHandlers.get_connected_clients, allow_head=False)
-
-            # Configure CORS on all routes.
-            for route in list(self.app.router.routes()):
-                cors.add(route)
+            setup_routes(self.app, cors)
 
         self.sio = None
         if Config.enable_socket_io_api:
@@ -312,12 +299,15 @@ class Server:
             logging.getLogger('aiohttp').setLevel(logging.ERROR)
             logging.getLogger('socketio').setLevel(logging.ERROR)
             logging.getLogger('engineio').setLevel(logging.ERROR)
-            logging.getLogger('siridb.connector').setLevel(logging.ERROR)
+            logging.getLogger(
+                'siridb.connector').setLevel(logging.ERROR)
 
-        self.app.on_shutdown.append(self._stop_server_from_aiohttp_cleanup)
+        self.app.on_shutdown.append(
+            self._stop_server_from_aiohttp_cleanup)
         self.loop.run_until_complete(self.start_up())
         try:
             web.run_app(
-                self.app, print=print_custom_aiohttp_startup_message, port=self.port)
+                self.app, print=print_custom_aiohttp_startup_message,
+                port=self.port)
         except (asyncio.CancelledError, RuntimeError):
             pass

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.1.0-beta3.0.0'
+VERSION = '0.1.0-beta4.0.0'

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.1.0-beta4.0.0'
+VERSION = '0.1.0-beta3.2.0'


### PR DESCRIPTION
### Added
- Seperate endpoints for fetching analysis result data

### Changed
- Changed series config and job config. Job config is now a list of jobs. Not categorised by job type. Forecast, anomaly detection jobs can be in the list multiple times. 
- Jobs get an unique identifier `config_name`, which can be set to now the `config_name` beforehand
- Jobs can be silenced by the silenced property in the job config. This makes sure no events will be created for the job's results.
- A job can require an other job the be run beforehand by using the `requires_job` property
- Config section `enodo` renamed to `hub` because of env prefix `ENODO_`

### Fixed
- PEP8 guidelines