### PR TITLE
Development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] - yyyy-mm-dd
 
+### Changed
+- Using `time.time()` instead of `datetime.datetime.now()` in rest of project
+
 ## [0.1.0-beta3.2.10] - 2022-05-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] - yyyy-mm-dd
 
+## [0.1.0-beta3.2.11] - 2022-05-23
+
+### Fixed
+- Ignore `requires_job` when config is not found (invalid job name)
+
 ### Changed
 - Using `time.time()` instead of `datetime.datetime.now()` in rest of project
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -82,7 +82,6 @@ class Config:
     _settings = None
     min_data_points = None
     watcher_interval = None
-    db = None
 
     # Siridb
     siridb_host = None

--- a/lib/jobmanager.py
+++ b/lib/jobmanager.py
@@ -299,7 +299,7 @@ class EnodoJobManager:
     @cls_lock()
     async def clean_jobs(cls):
         for job in cls._active_jobs:
-            now = time.time()
+            now = int(time.time())
             if (now - job.send_at) > cls._max_job_timeout:
                 await cls._set_job_failed(job, "Job timed-out")
                 await cls._send_worker_cancel_job(job.worker_id, job.rid)

--- a/lib/jobmanager.py
+++ b/lib/jobmanager.py
@@ -3,7 +3,6 @@ from asyncio import StreamWriter
 import datetime
 import logging
 import os
-import datetime
 import time
 from typing import Any, Callable, Optional, Union
 
@@ -56,10 +55,7 @@ class EnodoJob:
     def to_dict(cls, job: 'EnodoJob') -> dict:
         resp = {}
         for slot in cls.__slots__:
-            if isinstance(getattr(job, slot), datetime.datetime):
-                resp[slot] = int(getattr(job, slot).timestamp())
-            else:
-                resp[slot] = getattr(job, slot)
+            resp[slot] = getattr(job, slot)
         return resp
 
     @classmethod
@@ -303,8 +299,8 @@ class EnodoJobManager:
     @cls_lock()
     async def clean_jobs(cls):
         for job in cls._active_jobs:
-            now = datetime.datetime.now()
-            if (now - job.send_at).total_seconds() > cls._max_job_timeout:
+            now = time.time()
+            if (now - job.send_at) > cls._max_job_timeout:
                 await cls._set_job_failed(job, "Job timed-out")
                 await cls._send_worker_cancel_job(job.worker_id, job.rid)
 

--- a/lib/series/series.py
+++ b/lib/series/series.py
@@ -1,8 +1,9 @@
 import asyncio
 import time
+from typing import Optional
 
 from enodo.jobs import JOB_TYPE_BASE_SERIES_ANALYSIS, JOB_STATUS_NONE, \
-    JOB_STATUS_DONE
+    JOB_STATUS_DONE, JOB_STATUS_FAILED
 from enodo.model.config.series import SeriesConfigModel, SeriesState, \
     SeriesJobConfigModel
 
@@ -10,17 +11,20 @@ from lib.socket.clientmanager import ClientManager
 
 
 class Series:
-    __slots__ = ('rid', 'name', 'series_config', 'state',
+    __slots__ = ('rid', 'name', 'config', 'state',
                  '_datapoint_count_lock', 'series_characteristics')
 
-    def __init__(self, name: str, config: dict, state=None,
-                 series_characteristics=None, **kwargs):
+    def __init__(self,
+                 name: str,
+                 config:
+                 dict,
+                 state: Optional[dict] = None,
+                 series_characteristics: Optional[dict] = None,
+                 **kwargs):
         self.rid = name
         self.name = name
-        self.series_config = SeriesConfigModel(**config)
-        if state is None:
-            state = {}
-        self.state = SeriesState(**state)
+        self.config = SeriesConfigModel(**config)
+        self.state = {} if state is None else SeriesState(**state)
         self.series_characteristics = series_characteristics
         self._datapoint_count_lock = asyncio.Lock()
 
@@ -39,7 +43,7 @@ class Series:
         return EnodoJobManager.has_series_failed_jobs(self.name)
 
     async def get_module(self, job_name: str) -> SeriesJobConfigModel:
-        return self.series_config.get_config_for_job(job_name).module
+        return self.config.get_config_for_job(job_name).module
 
     async def get_job_status(self, job_config_name: str) -> int:
         return self.state.get_job_status(job_config_name)
@@ -49,17 +53,17 @@ class Series:
 
     @property
     def base_analysis_job(self) -> SeriesJobConfigModel:
-        job_config = self.series_config.get_config_for_job_type(
+        job_config = self.config.get_config_for_job_type(
             JOB_TYPE_BASE_SERIES_ANALYSIS)
         if job_config is None or job_config is False:
             return False
         return job_config
 
     def get_job(self, job_config_name: str) -> SeriesJobConfigModel:
-        return self.series_config.get_config_for_job(job_config_name)
+        return self.config.get_config_for_job(job_config_name)
 
     def base_analysis_status(self) -> int:
-        job_config = self.series_config.get_config_for_job_type(
+        job_config = self.config.get_config_for_job_type(
             JOB_TYPE_BASE_SERIES_ANALYSIS)
         if job_config is None or job_config is False:
             return False
@@ -78,8 +82,7 @@ class Series:
             self.state.datapoint_count += add_to_count
 
     async def schedule_job(self, job_config_name: str, initial=False):
-        job_config = self.series_config.get_config_for_job(
-            job_config_name)
+        job_config = self.config.get_config_for_job(job_config_name)
         if job_config is None:
             return False
 
@@ -111,44 +114,43 @@ class Series:
         job_status = self.state.get_job_status(job_config_name)
         job_schedule = self.state.get_job_schedule(job_config_name)
 
-        if job_status in [JOB_STATUS_NONE, JOB_STATUS_DONE]:
-            job_config = self.series_config.get_config_for_job(
-                job_config_name)
-            module = ClientManager.get_module(job_config.module)
-            if module is None:
+        if job_status not in [JOB_STATUS_NONE, JOB_STATUS_DONE]:
+            jcs = "Job failed" if job_status == JOB_STATUS_FAILED else \
+                "Already active"
+            self.state.set_job_check_status(job_config_name, jcs)
+            return False
+
+        job_config = self.config.get_config_for_job(job_config_name)
+        module = ClientManager.get_module(job_config.module)
+        if module is None:
+            self.state.set_job_check_status(
+                job_config_name, "Unknown module")
+            return False
+        r_job = job_config.requires_job
+        if r_job is not None and self.config.get_config_for_job(
+                r_job) is not None:
+            required_job_status = self.state.get_job_status(r_job)
+            if required_job_status is not JOB_STATUS_DONE:
                 self.state.set_job_check_status(
                     job_config_name,
-                    "Unknown module")
+                    f"Waiting for required job {r_job}")
                 return False
-            if job_config.requires_job is not None:
-                required_job_status = self.state.get_job_status(
-                    job_config.requires_job)
-                if required_job_status is not JOB_STATUS_DONE:
-                    self.state.set_job_check_status(
-                        job_config_name,
-                        f"Waiting for required job {job_config.requires_job}")
-                    return False
-            if job_schedule["value"] is None:
-                return True
-            if job_schedule["type"] == "TS" and \
-                    job_schedule["value"] <= int(time.time()):
-                return True
-            if job_schedule["type"] == "N" and \
-                    job_schedule["value"] <= self.state.datapoint_count:
-                return True
-            self.state.set_job_check_status(
-                job_config_name,
-                "Not yet scheduled")
-            return False
+        if job_schedule["value"] is None:
+            return True
+        if job_schedule["type"] == "TS" and \
+                job_schedule["value"] <= int(time.time()):
+            return True
+        if job_schedule["type"] == "N" and \
+                job_schedule["value"] <= self.state.datapoint_count:
+            return True
         self.state.set_job_check_status(
-            job_config_name,
-            "Already active")
+            job_config_name, "Not yet scheduled")
         return False
 
     def update(self, data: dict) -> bool:
         config = data.get('config')
         if config is not None:
-            self.series_config = SeriesConfigModel(**config)
+            self.config = SeriesConfigModel(**config)
 
         return True
 
@@ -157,14 +159,14 @@ class Series:
             return {
                 'name': self.name,
                 'state': self.state,
-                'config': self.series_config,
+                'config': self.config,
                 'series_characteristics': self.series_characteristics
             }
         return {
             'rid': self.rid,
             'name': self.name,
             'state': self.state,
-            'config': self.series_config,
+            'config': self.config,
             'ignore': self.is_ignored(),
             'error': self.get_errors(),
             'series_characteristics': self.series_characteristics

--- a/lib/series/seriesmanager.py
+++ b/lib/series/seriesmanager.py
@@ -82,7 +82,7 @@ class SeriesManager:
     @classmethod
     def get_listener_series_info(cls):
         series = [{"name": series_name,
-                   "realtime": series.series_config.realtime}
+                   "realtime": series.config.realtime}
                   for series_name, series in cls._series.items()]
         labels = [
             {"name": label.get('selector'),

--- a/lib/socket/clientmanager.py
+++ b/lib/socket/clientmanager.py
@@ -21,21 +21,26 @@ from lib.util.util import load_disk_data, save_disk_data
 
 class EnodoClient:
 
-    def __init__(self,
-                 client_id: str,
-                 ip_address: str,
-                 writer: StreamWriter,
-                 version: Optional[str] = "unknown",
-                 last_seen: Optional[int] = None,
-                 online=True):
+    def __init__(
+            self, client_id: str, ip_address: str, writer: StreamWriter,
+            version: Optional[str] = "unknown",
+            last_seen: Optional[Union[str, Union[float, int]]] = None,
+            online=True):
         self.client_id = client_id
         self.ip_address = ip_address
         self.writer = writer
-        self.last_seen = last_seen
         self.version = version
         self.online = online
-        if last_seen is None:
-            self.last_seen = int(time.time())
+        self._last_seen = int(time.time()) if last_seen is None \
+            else int(last_seen)
+
+    @property
+    def last_seen(self) -> int:
+        return self._last_seen
+
+    @last_seen.setter
+    def last_seen(self, val: Union[str, Union[float, int]]):
+        self._last_seen = int(val)
 
     async def reconnected(self, ip_address: str, writer: StreamWriter):
         self.online = True

--- a/lib/socket/socketserver.py
+++ b/lib/socket/socketserver.py
@@ -1,5 +1,4 @@
 import asyncio
-import datetime
 import logging
 import time
 from packaging import version
@@ -98,13 +97,13 @@ class SocketServer:
         if l_client is not None:
             logging.debug(
                 f'Heartbeat from listener with id: {client_id}')
-            l_client.last_seen = int(time.time())
+            l_client.last_seen = time.time()
             response = create_header(0, HEARTBEAT, packet_id)
             writer.write(response)
         elif w_client is not None:
             logging.debug(
                 f'Heartbeat from worker with id: {client_id}')
-            w_client.last_seen = int(time.time())
+            w_client.last_seen = time.time()
             response = create_header(0, HEARTBEAT, packet_id)
             writer.write(response)
         else:

--- a/server.py
+++ b/server.py
@@ -215,7 +215,7 @@ class Server:
 
         # loop through scheduled jobs:
         job_schedules = series.state.get_all_job_schedules()
-        for job_config_name in series.series_config.job_config:
+        for job_config_name in series.config.job_config:
             if job_config_name in job_schedules and \
                     await series.is_job_due(job_config_name):
                 await EnodoJobManager.create_job(job_config_name, series_name)
@@ -242,9 +242,9 @@ class Server:
                 # Check if requirement of min amount of datapoints is met
                 if series.get_datapoints_count() is None:
                     continue
-                if series.series_config.min_data_points is not None:
+                if series.config.min_data_points is not None:
                     if series.get_datapoints_count() < \
-                            series.series_config.min_data_points:
+                            series.config.min_data_points:
                         continue
                 elif series.get_datapoints_count() < Config.min_data_points:
                     continue

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.1.0-beta3.2.10'
+VERSION = '0.1.0-beta3.2.11'


### PR DESCRIPTION
### Fixed
- Ignore `requires_job` when config is not found (invalid job name)

### Changed
- Using `time.time()` instead of `datetime.datetime.now()` in rest of project