### PR TITLE
Storage rid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] - yyyy-mm-dd
 
+## [0.1.0-beta4.0.2] - 2022-07-28
+
+### Fixed
+- Ensure thingsdb upgrades run even when hub version has none set
+
 ## [0.1.0-beta4.0.1] - 2022-07-28
 
 ### Fixed

--- a/lib/util/upgrade.py
+++ b/lib/util/upgrade.py
@@ -34,8 +34,8 @@ class UpgradeUtil:
             if version == thingsdb_hub_version:
                 index_of_thingsdb_hub_version = idx
 
-        if index_of_current_version is None:
-            return
+        # if index_of_current_version is None:
+        #     return
         found_first = False
         updates_ran = 0
         if index_of_thingsdb_hub_version == 0:

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.1.0-beta4.0.1'
+VERSION = '0.1.0-beta4.0.2'


### PR DESCRIPTION
## [0.1.0-beta4.0.2] - 2022-07-28

### Fixed
- Ensure thingsdb upgrades run even when hub version has none set