### PR TITLE
fix bug seriesstate, job meta in output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] - yyyy-mm-dd
 
+## [0.1.0-beta4.0.3] - 2022-07-28
+
+### Fixed
+- SeriesState: Removed default initialisation away from class attributes
+- Decode job meta when returning job results
+
 ## [0.1.0-beta4.0.2] - 2022-07-28
 
 ### Fixed

--- a/lib/series/seriesmanager.py
+++ b/lib/series/seriesmanager.py
@@ -94,6 +94,7 @@ class SeriesManager:
                 if series.get('name') not in cls._states:
                     cls._states[series.get('name')] = SeriesState(
                         series.get('name'))
+                    cls._states[series.get('name')].defaults()
                 cls._states[series.get('name')].datapoint_count = \
                     collected_datapoints
             asyncio.ensure_future(cls.series_changed(
@@ -133,6 +134,7 @@ class SeriesManager:
         state = cls._states.get(series_name)
         if state is None:
             cls._states[series_name] = SeriesState(series_name)
+            cls._states[series_name].defaults()
             yield cls._states[series_name]
             return
         async with state.lock:
@@ -140,14 +142,18 @@ class SeriesManager:
 
     @classmethod
     def get_state_read_only(cls, series_name):
-        return cls._states.get(series_name, SeriesState(series_name))
+        if cls._states.get(series_name) is not None:
+            return cls._states[series_name]
+        s = SeriesState(series_name)
+        s.defaults()
+        return s
 
     @classmethod
     async def get_series_read_only(cls, series_name):
         state = cls._states.get(series_name)
         if state is None:
-            state = SeriesState(series_name)
-            cls._states[series_name] = state
+            cls._states[series_name] = SeriesState(series_name)
+            cls._states[series_name].defaults()
         return await cls._srm.get_resource_by_key("name", series_name), state
 
     @classmethod

--- a/lib/series/seriesstate.py
+++ b/lib/series/seriesstate.py
@@ -36,10 +36,16 @@ class SeriesState(dataobject):
     health: float = None
     interval: int = None
     characteristics: str = None
-    job_data: list = []
-    lock = asyncio.Lock()
+    job_data: list = None
+    lock: asyncio.Lock = None
     last_checked_dp: int = None
     _update_dp_at: int = None
+
+    def defaults(self):
+        if self.job_data is None:
+            self.job_data = []
+        if self.lock is None:
+            self.lock = asyncio.Lock()
 
     @classmethod
     def unserialize(cls, data):
@@ -49,6 +55,7 @@ class SeriesState(dataobject):
             state.job_data = job_data
         except Exception:
             return None
+        state.lock = asyncio.Lock()
         return state
 
     def serialize(self):
@@ -105,8 +112,10 @@ class SeriesState(dataobject):
     def set_job_check_status(self, config_name: str, status: str):
         self._get_job(config_name).check_status = status
 
-    def get_job_meta(self, job_config_name: str) -> int:
-        return self._get_job(job_config_name).analysis_meta
+    def get_job_meta(self, job_config_name: str) -> str:
+        job = self._get_job(job_config_name)
+        return json.loads(
+            job.analysis_meta) if job.analysis_meta else ""
 
     def set_job_meta(self, config_name: str, analysis_meta: Any):
         self._get_job(config_name).analysis_meta = json.dumps(

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.1.0-beta4.0.2'
+VERSION = '0.1.0-beta4.0.3'


### PR DESCRIPTION
## [0.1.0-beta4.0.3] - 2022-07-28

### Fixed
- SeriesState: Removed default initialisation away from class attributes
- Decode job meta when returning job results