### PR TITLE
ssl fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] - yyyy-mm-dd
 
+## [0.1.0-beta4.0.5] - 2022-08-01
+
+### Changed
+- Disabled strict ssl for event output calls (webhook)
+
 ## [0.1.0-beta4.0.4] - 2022-08-01
 
 ### Changed

--- a/lib/eventmanager.py
+++ b/lib/eventmanager.py
@@ -172,7 +172,8 @@ class EnodoEventOutputWebhook(EnodoEventOutput):
                 logging.debug(
                     f'Calling EnodoEventOutput webhook {self.url}')
                 async with aiohttp.ClientSession(
-                        timeout=aiohttp.ClientTimeout(total=3)) as session:
+                        timeout=aiohttp.ClientTimeout(total=3),
+                        ssl=False) as session:
                     await session.post(
                         self.url,
                         data=self._get_payload(event),

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.1.0-beta4.0.4'
+VERSION = '0.1.0-beta4.0.5'


### PR DESCRIPTION
## [0.1.0-beta4.0.5] - 2022-08-01

### Changed
- Disabled strict ssl for event output calls (webhook)