### PR TITLE
Fix results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] - yyyy-mm-dd
 
+## [0.1.0-beta4.0.7] - 2022-08-03
+
+### Fixed
+- When results are queried, return empty object for `job_meta` if it is empty, instead of an empty string
+
 ## [0.1.0-beta4.0.6] - 2022-08-01
 
 ### Added

--- a/lib/series/seriesstate.py
+++ b/lib/series/seriesstate.py
@@ -120,7 +120,7 @@ class SeriesState(dataobject):
     def get_job_meta(self, job_config_name: str) -> str:
         job = self._get_job(job_config_name)
         return json.loads(
-            job.analysis_meta) if job.analysis_meta else ""
+            job.analysis_meta) if job.analysis_meta else {}
 
     def set_job_meta(self, config_name: str, analysis_meta: Any):
         self._get_job(config_name).analysis_meta = json.dumps(
@@ -220,7 +220,7 @@ class SeriesState(dataobject):
             "datapoint_count": self.datapoint_count,
             "health": self.health,
             "characteristics": json.loads(
-                self.characteristics) if self.characteristics else "",
+                self.characteristics) if self.characteristics else {},
             "interval": self.interval,
             "job_schedule": self.get_all_job_schedules(),
             "job_statuses": {},
@@ -239,6 +239,6 @@ class SeriesState(dataobject):
             state["job_check_statuses"][
                 job.config_name] = job.check_status
             state["job_analysis_meta"][job.config_name] = json.loads(
-                job.analysis_meta) if job.analysis_meta else ""
+                job.analysis_meta) if job.analysis_meta else {}
 
         return state

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.1.0-beta4.0.6'
+VERSION = '0.1.0-beta4.0.7'


### PR DESCRIPTION
## [0.1.0-beta4.0.7] - 2022-08-03

### Fixed
- When results are queried, return empty object for `job_meta` if it is empty, instead of an empty string