### PR TITLE
api fix, interval default for schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] - yyyy-mm-dd
 
+## [0.1.0-beta4.0.15] - 2022-08-05
+
+### Fixed
+- Use default interval when base job has not ran before
+- Fixed better error message when adding series with unknown config template
+
 ## [0.1.0-beta4.0.14] - 2022-08-05
 
 ### Fixed

--- a/lib/series/series.py
+++ b/lib/series/series.py
@@ -115,8 +115,9 @@ class Series(StoredResource):
         if not dp_ok:
             if job_schedule["type"] == "TS":
                 diff = min_points - state.datapoint_count
+                interval = state.interval if state.interval is not None else 60
                 job_schedule['value'] = int(
-                    time.time()) + diff * state.interval
+                    time.time()) + diff * interval
             elif job_schedule["type"] == "N":
                 job_schedule['value'] = min_points
             asyncio.ensure_future(state.update_datapoints_count())

--- a/lib/webserver/basehandler.py
+++ b/lib/webserver/basehandler.py
@@ -225,6 +225,11 @@ class BaseHandler:
             if bc is None:
                 return {'error': 'Something went wrong when adding '
                         'the series. Missing base analysis job'}, 400
+        else:
+            config = ServerState.series_config_template_rm.get_cached_resource(
+                int(data.get('config')))
+            if config is None:
+                return {'error': 'Series config template not found'}, 404
         if 'meta' in data and (data.get('meta') is not None and
                                not isinstance(data.get('meta'), dict)):
             return {'error': 'Something went wrong when adding '

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.1.0-beta4.0.14'
+VERSION = '0.1.0-beta4.0.15'


### PR DESCRIPTION
## [0.1.0-beta4.0.15] - 2022-08-05

### Fixed
- Use default interval when base job has not ran before
- Fixed better error message when adding series with unknown config template