### PR TITLE
fix settings update and queue event max once a hour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] - yyyy-mm-dd
 
+## [0.1.0-beta4.0.20] - 2022-09-27
+
+### Fixed
+- Settings update endpoint
+- Send queue too long event max once every hour
+
 ## [0.1.0-beta4.0.19] - 2022-09-07
 
 ### Fixed

--- a/lib/socketio/socketiohandlers.py
+++ b/lib/socketio/socketiohandlers.py
@@ -240,7 +240,7 @@ class SocketIoHandler:
     @classmethod
     @socketio_auth_required
     async def update_enodo_hub_settings(cls, sid, data, event):
-        resp = BaseHandler.resp_set_config(data)
+        resp = await BaseHandler.resp_set_config(data)
         return resp
 
     @classmethod

--- a/lib/webserver/apihandlers.py
+++ b/lib/webserver/apihandlers.py
@@ -529,7 +529,7 @@ class ApiHandlers:
             key/value pairs settings
         """
         data = await request.json()
-        resp = BaseHandler.resp_set_config(data)
+        resp = await BaseHandler.resp_set_config(data)
         return web.json_response(data=resp, status=200)
 
     @classmethod

--- a/lib/webserver/basehandler.py
+++ b/lib/webserver/basehandler.py
@@ -467,7 +467,7 @@ class BaseHandler:
         return {'data': Config.get_settings(include_secrets=False)}
 
     @classmethod
-    def resp_set_config(cls, data):
+    async def resp_set_config(cls, data):
         """Update config
 
         Args:
@@ -479,7 +479,7 @@ class BaseHandler:
         keys_and_values = data.get('entries')
         for key in keys_and_values:
             if Config.is_runtime_configurable(key):
-                Config.update_settings(
+                await Config.update_settings(
                     ServerState.storage.client,
                     key, keys_and_values[key])
 

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.1.0-beta4.0.19'
+VERSION = '0.1.0-beta4.0.20'


### PR DESCRIPTION
## [0.1.0-beta4.0.20] - 2022-09-27

### Fixed
- Settings update endpoint
- Send queue too long event max once every hour